### PR TITLE
Test plan: Remove doc history from header

### DIFF
--- a/testplan/header.go
+++ b/testplan/header.go
@@ -25,23 +25,10 @@ ifndef::env-github[]
 endif::[]
 :sectanchors:
 :doctype: book
-:revnumber: 0.1
-:revdate: %s
 :author: Matter CSG Test Plans Tiger Team
 :sectnums:
 :picsCode: %s
 :clustername: %s
-
-ifdef::env-github[]
-*Document History*
-|===
-|*Rev*|*Date*|*Author*|*Description*
-|0.1|%s|<author>|Initial Test Plan for {picsCode}
-|===
-
-*Common Introduction*
-include::intro.adoc[Introduction]
-endif::[]
 
 // Common AsciiDocAttributes
 include::../common/cluster_common.adoc[]


### PR DESCRIPTION
This was removed from the test plans in
https://github.com/CHIP-Specifications/chip-test-plans/pull/4216