### PR TITLE
correct flag --dmRoot for alchemy dm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-
-
 # Alchemy
 
 Alchemy is a command line tool for modifying and transforming Matter spec documents.
@@ -222,10 +220,10 @@ conformance: Disallowed
 
 Data Model generates the Data Model XML files from the spec.
 
-| Flag                       | Default                | Description   |	
-| :------------------------- |:----------------------:| :-------------|
-| --specRoot                 | ./connectedhomeip-spec | The root of your clone of [the Matter Specification](https://github.com/CHIP-Specifications/connectedhomeip-spec/) |
-| --sdkRoot                  | ./connectedhomeip      | The root of your clone of [the Matter SDK](https://github.com/project-chip/connectedhomeip/) |
+| Flag                       | Default                                  | Description   |	
+| :------------------------- |:----------------------------------------:| :-------------|
+| --specRoot                 | ./connectedhomeip-spec                   | The root of your clone of [the Matter Specification](https://github.com/CHIP-Specifications/connectedhomeip-spec/) |
+| --dmRoot                   | ./connectedhomeip/data_model/master      | The data model directory of your clone of [the Matter SDK](https://github.com/project-chip/connectedhomeip/) |
 
 
 ### testplan


### PR DESCRIPTION
Align documentation with usage string from alchemy dm -h.

```
alchemy dm -h      
transmute the Matter spec into data model XML

Usage:
  alchemy dm [flags]

Aliases:
  dm, datamodel, data-model

Flags:
      --dmRoot string     where to place the data model files (default "connectedhomeip/data_model/master")
  -h, --help              help for dm
      --specRoot string   the src root of your clone of CHIP-Specifications/connectedhomeip-spec (default "connectedhomeip-spec")

Global Flags:
  -a, --attribute strings   attribute for pre-processing asciidoc; this flag can be provided more than once
  -d, --dryrun              whether or not to actually output files
  -p, --patch               generate patch file
      --serial              process files one-by-one
      --verbose             display verbose information
```

Fixes https://github.com/project-chip/alchemy/issues/13.