### PR TITLE
Errdiff

### DIFF
--- a/cmd/action/github/pr.go
+++ b/cmd/action/github/pr.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/google/go-github/v60/github"
 	"github.com/sethvargo/go-githubactions"
@@ -168,30 +167,30 @@ func WriteComment(cxt context.Context, githubContext *githubactions.GitHubContex
 
 	messageIdComment := fmt.Sprintf("<!-- add-pr-comment:%s -->", messageId)
 	slog.Info("fetched comments", "total", len(comments))
-	var existingComment *github.IssueComment
-	for _, c := range comments {
-		slog.Info("comment", slog.Any("c", c))
-		body := c.GetBody()
-		if strings.HasPrefix(body, messageIdComment) {
-			existingComment = c
-			break
-		}
-	}
+	// var existingComment *github.IssueComment
+	// for _, c := range comments {
+	// 	slog.Info("comment", slog.Any("c", c))
+	// 	body := c.GetBody()
+	// 	if strings.HasPrefix(body, messageIdComment) {
+	// 		existingComment = c
+	// 	}
+	// }
 
 	comment = fmt.Sprintf("%s\n\n%s", messageIdComment, comment)
 	ic := &github.IssueComment{Body: &comment}
-	if existingComment != nil {
-		_, _, err = client.Issues.EditComment(cxt, owner, repo, existingComment.GetID(), ic)
-		if err != nil {
-			err = fmt.Errorf("failed editing comment: %w", err)
-			return
-		}
-	} else {
-		_, _, err = client.Issues.CreateComment(cxt, owner, repo, pr.GetNumber(), ic)
-		if err != nil {
-			err = fmt.Errorf("failed creating comment: %w", err)
-			return
-		}
+	// if existingComment != nil {
+	// 	_, _, err = client.Issues.EditComment(cxt, owner, repo, existingComment.GetID(), ic)
+	// 	if err != nil {
+	// 		err = fmt.Errorf("failed editing comment: %w", err)
+	// 		return
+	// 	}
+	// } else {
+	_, _, err = client.Issues.CreateComment(cxt, owner, repo, pr.GetNumber(), ic)
+	if err != nil {
+		err = fmt.Errorf("failed creating comment: %w", err)
+		return
 	}
+	// }
+
 	return
 }

--- a/cmd/action/merge_guard.go
+++ b/cmd/action/merge_guard.go
@@ -180,7 +180,7 @@ func (c *MergeGuard) Run(cc *cli.Context) (err error) {
 					vv.Violations = append(vv.Violations, "Not in in-progress ifdef")
 				}
 				if v.Type.Has(spec.ViolationNewParseError) {
-					vv.Violations = append(vv.Violations, "New Parse Error introduced by this PR")
+					vv.Violations = append(vv.Violations, "New Parse Error introduced by this PR: "+v.Text)
 				}
 				vf.Violations = append(vf.Violations, vv)
 			}

--- a/errdiff/pipeline.go
+++ b/errdiff/pipeline.go
@@ -83,7 +83,7 @@ func compareErrors(Base *spec.Specification, Head *spec.Specification) (violatio
 
 					if matchingError := findMatchingError(entityToFind, baseErrorsAsError); matchingError == nil {
 						slog.Error("This error is introduced by the current PR: <", headErr.Error(), ">")
-						v := spec.Violation{Entity: entityToFind, Type: spec.ViolationNewParseError}
+						v := spec.Violation{Entity: entityToFind, Type: spec.ViolationNewParseError, Text: headErr.Error()}
 						source, ok := entityToFind.(log.Source)
 						if ok {
 							v.Path, v.Line = source.Origin()
@@ -100,7 +100,7 @@ func compareErrors(Base *spec.Specification, Head *spec.Specification) (violatio
 						continue
 					}
 					slog.Error("This error is introduced by the current PR: <", headErr.Error(), ">")
-					v := spec.Violation{Entity: entityToFind, Type: spec.ViolationNewParseError}
+					v := spec.Violation{Entity: entityToFind, Type: spec.ViolationNewParseError, Text: headErr.Error()}
 					source, ok := entityToFind.(log.Source)
 					if ok {
 						v.Path, v.Line = source.Origin()

--- a/matter/spec/violation.go
+++ b/matter/spec/violation.go
@@ -39,6 +39,7 @@ type Violation struct {
 	Entity types.Entity
 	Path   string
 	Line   int
+	Text   string
 }
 
 func MergeViolations(v1, v2 map[string][]Violation) (v map[string][]Violation) {


### PR DESCRIPTION
This PR adds the following functionalities to Alchemy:

1. A new package called ErrDiff, which takes two copies of specs (intended to be a working head and a base) and checks if there are new parse errors introduced by head.
2. An existing github action called provisional is now extended to run ErrDiff as well. The provisional github action is now renamed to Merge Guard that will act as a guard against provisionality errors and new parse errors. The already existing errors will not be considered by Merge Guard.

The following are modifications to the existing functionality:

1. Merge Guard (expanded from provisionality) will not update the first existing comment on github PR. This is to prevent confusions after pushing new commits to a PR.
2. Provisionality Pipeline is divided into two parts. The pipeline itself and `ProcessSpecs`. The pipeline simply loads the spec and feed it to `ProcessSpecs` to do the comparison logic. This helps the Merge Guard to only load the specs once and feed them to Provisional and ErrDiff.  