### PR TITLE
Make `ClientDirectories` an optional key for zap cluster list.

### DIFF
--- a/zap/render/cluster_list.go
+++ b/zap/render/cluster_list.go
@@ -78,12 +78,12 @@ func (p ClusterListPatcher) Process(cxt context.Context, inputs []*pipeline.Data
 		}
 	}
 
-	err = insertClusterName(&o, "ClientDirectories", names)
+	err = insertClusterName(&o, "ClientDirectories", names, true /* optional */)
 	if err != nil {
 		return
 	}
 
-	err = insertClusterName(&o, "ServerDirectories", names)
+	err = insertClusterName(&o, "ServerDirectories", names, false /* optional */)
 	if err != nil {
 		return
 	}
@@ -97,9 +97,12 @@ func (p ClusterListPatcher) Process(cxt context.Context, inputs []*pipeline.Data
 	return
 }
 
-func insertClusterName(o *internal.JSONMap, key string, names []string) error {
+func insertClusterName(o *internal.JSONMap, key string, names []string, optional bool) error {
 	val, ok := o.Get(key)
 	if !ok {
+		if optional {
+			return nil
+		}
 		return fmt.Errorf("no %s field in zap_cluster_list.json", key)
 	}
 	is, ok := val.(*internal.JSONMap)


### PR DESCRIPTION
No clusters currently have client directories in matter, consider this optional so that we can remove the list alltogether.