### PR TITLE
Fix hard coded version in zap command

### DIFF
--- a/zap/render/version.go
+++ b/zap/render/version.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/beevik/etree"
 	"github.com/project-chip/alchemy/zap"
+	"github.com/project-chip/alchemy/config"
 )
 
 func (cr *configuratorRenderer) patchComments(configurator *zap.Configurator, x *etree.Document) error {
@@ -126,7 +127,7 @@ func (cr *configuratorRenderer) patchAlchemyComment(configurator *zap.Configurat
 		Path:       strings.Join(paths, " "),
 		Parameters: args,
 		Git:        cr.generator.specVersion,
-		Version:    "v1.5.50",
+		Version:    config.Version(),
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
#### Summary
Fix the version being hard coded in the zap command. This will now take the version number from the config when creating the comment on xml docs showing the alchemy version used.

#### Testing
Ran alchemy zap command and checked the XML docs were displaying the correct version.