### PR TITLE
Update Disco Ball Template

### DIFF
--- a/cmd/action/github/templates/disco/patched.handlebars
+++ b/cmd/action/github/templates/disco/patched.handlebars
@@ -1,9 +1,10 @@
 <a href="https://github.com/project-chip/alchemy"></a><img align="left" width="75" height="75" src="https://raw.githubusercontent.com/project-chip/alchemy/refs/heads/main/alchemy.svg"></a>
-<a href="https://github.com/project-chip/alchemy">Alchemy</a> found disco-ball suggestions for this commit.
+<a href="https://github.com/project-chip/alchemy">Alchemy</a> found disco-ball fixes for this PR.
 <br/>
 
-> [!TIP]
-> Apply it to your PR by running <kbd>patch < disco.patch</kbd> in the root of your repo.
+> [!CAUTION]
+> Apply it to your PR by running <kbd>patch -p0 < disco.patch</kbd> in the root of your repo.
+> These fixes must be applied before this PR can be merged.
 
 <a href="{{patch_url}}"><kbd><br/>&nbsp; 🔽 &nbsp;Download Patch File&nbsp;&nbsp;<br/><br/></kbd></a>
 


### PR DESCRIPTION
- Text updated from "suggestions" to "fixes".
- Added a [!CAUTION] block explicitly stating: "These fixes must be applied before this PR can be merged."
- Updated the local patch command to use `-p0`.