### PR TITLE
Skip elements with provisional ancestors

### DIFF
--- a/provisional/compare.go
+++ b/provisional/compare.go
@@ -60,8 +60,8 @@ func compare(specs spec.SpecPullRequest) (violationsByPath map[string][]spec.Vio
 			parent = parent.Parent()
 		}
 
-		// When an ancestor is provisional, we don't need to report violations for this entity
-		if parent != nil {
+		// When an ancestor is provisional, we don't need to report non-provisional violations for this entity
+		if (violationType == spec.ViolationTypeNonProvisional) && (parent != nil) {
 			continue
 		}
 

--- a/provisional/compare.go
+++ b/provisional/compare.go
@@ -60,6 +60,11 @@ func compare(specs spec.SpecPullRequest) (violationsByPath map[string][]spec.Vio
 			parent = parent.Parent()
 		}
 
+		// When an ancestor is provisional, we don't need to report violations for this entity
+		if parent != nil {
+			continue
+		}
+
 		v := spec.Violation{Entity: entity, Type: violationType}
 		v.Path, v.Line = entity.Origin()
 		violationsByPath[v.Path] = append(violationsByPath[v.Path], v)

--- a/provisional/compare.go
+++ b/provisional/compare.go
@@ -61,8 +61,11 @@ func compare(specs spec.SpecPullRequest) (violationsByPath map[string][]spec.Vio
 		}
 
 		// When an ancestor is provisional, we don't need to report non-provisional violations for this entity
-		if (violationType == spec.ViolationTypeNonProvisional) && (parent != nil) {
-			continue
+		if parent != nil {
+			violationType &= ^spec.ViolationTypeNonProvisional
+			if violationType == spec.ViolationTypeNone {
+				continue
+			}
 		}
 
 		v := spec.Violation{Entity: entity, Type: violationType}

--- a/provisional/compare_test.go
+++ b/provisional/compare_test.go
@@ -1,0 +1,75 @@
+package provisional_test
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/project-chip/alchemy/internal/pipeline"
+	"github.com/project-chip/alchemy/matter/spec"
+	"github.com/project-chip/alchemy/provisional"
+)
+
+func TestCompareProvisional_FileBased_Cases(t *testing.T) {
+	// Set debug level to error
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})))
+
+	cxt := context.Background()
+	baseRoot := "testdata/base"
+	headRoot := "testdata/head"
+
+	processingOptions := pipeline.ProcessingOptions{}
+
+	violations, err := provisional.Pipeline(cxt, baseRoot, headRoot, nil, processingOptions, nil)
+	if err != nil {
+		t.Fatalf("Pipeline failed: %v", err)
+	}
+
+	// We read test_cluster.adoc which contains 4 cases:
+	//
+	// Case 1: ProvCommand1 and Field1
+	// - ProvCommand1 is an existing provisional command (matched by ID 0x00 to base).
+	// - Field1 is a NEW non-provisional field added to it, inside if-def.
+	// - Field1 triggers NonProvisional violation, but it is MASKED by provisional parent ProvCommand1.
+	// - Result: PASSES. Verifies ancestor resolving logic.
+	//
+	// Case 2: ProvCommand2
+	// - Marked provisional (P) in table.
+	// - NOT inside ifdef::in-progress[].
+	// - Result: FAILS (NotIfDefd). Provisional entities must be in ifdef.
+	//
+	// Case 3: ProvCommand3
+	// - Marked provisional (P) in table.
+	// - Inside ifdef::in-progress[].
+	// - Result: PASSES. It is properly ifdef'd.
+	//
+	// Case 4: NonProvCommand
+	// - Marked mandatory (M) (not provisional) in table.
+	// - Inside ifdef::in-progress[].
+	// - Result: FAILS (NonProvisional). Non-provisional entities should not be in in-progress ifdef.
+
+	expectedNotIfDefd := 0
+	expectedNonProvisional := 0
+
+	for _, vs := range violations {
+		for _, v := range vs {
+			if v.Type.Has(spec.ViolationTypeNotIfDefd) {
+				expectedNotIfDefd++
+			}
+			if v.Type.Has(spec.ViolationTypeNonProvisional) {
+				expectedNonProvisional++
+			}
+		}
+	}
+
+	// We expect 1 NotIfDefd: for ProvCommand2 (no ifdef).
+	if expectedNotIfDefd != 1 {
+		t.Errorf("Expected 1 NotIfDefd violations, got %d", expectedNotIfDefd)
+	}
+
+	// We expect 1 NonProvisional: for NonProvCommand (Case 4: not provisional in ifdef).
+	if expectedNonProvisional != 1 {
+		t.Errorf("Expected 1 NonProvisional violation, got %d", expectedNonProvisional)
+	}
+}

--- a/provisional/compare_test.go
+++ b/provisional/compare_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestCompareProvisional_FileBased_Cases(t *testing.T) {
-	// Set debug level to error
 	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})))
 
 	cxt := context.Background()

--- a/provisional/testdata/base/src/app_clusters/test_cluster.adoc
+++ b/provisional/testdata/base/src/app_clusters/test_cluster.adoc
@@ -1,0 +1,24 @@
+[[ref_TestCluster, Test Cluster]]
+= Test Cluster
+
+== Classification
+
+|===
+| Hierarchy | Role        | Scope    | PICS Code
+| Base      | Application | Endpoint | TEST
+|===
+
+== Cluster Identifiers
+
+[options="header",valign="middle"]
+|===
+| Identification     | Name
+| 0xFFFE             | Test Cluster
+|===
+
+== Commands
+[options="header",valign="middle"]
+|===
+| ID     | Name           | Direction        | Response      | Access | Conformance
+| 0x00  s| TestCommand    | client => server | Y                 | O      | P
+|===

--- a/provisional/testdata/base/src/device_types/BaseDeviceType.adoc
+++ b/provisional/testdata/base/src/device_types/BaseDeviceType.adoc
@@ -1,0 +1,16 @@
+[[ref_BaseDeviceType, Base Device Type]]
+= Base Device Type
+
+== Classification
+[options="header",valign="middle"]
+|===
+| Device Name      | Device Type ID | Device Type Revision
+| Base Device Type | 0xFFFE         | 1
+|===
+
+== Cluster Requirements
+[options="header",valign="middle"]
+|===
+| Cluster | Client/Server | Conformance
+| Basic Information | Server | M
+|===

--- a/provisional/testdata/base/src/device_types/RootNode.adoc
+++ b/provisional/testdata/base/src/device_types/RootNode.adoc
@@ -1,0 +1,16 @@
+[[ref_RootNode, Root Node]]
+= Root Node
+
+== Classification
+[options="header",valign="middle"]
+|===
+| Device Name | Device Type ID | Device Type Revision
+| Root Node   | 0x0016         | 1
+|===
+
+== Cluster Requirements
+[options="header",valign="middle"]
+|===
+| Cluster | Client/Server | Conformance
+| Basic Information | Server | M
+|===

--- a/provisional/testdata/base/src/main.adoc
+++ b/provisional/testdata/base/src/main.adoc
@@ -1,0 +1,7 @@
+= Main Spec
+
+include::service_device_management/BasicInformationCluster.adoc[]
+include::service_device_management/BridgedDeviceBasicInformationCluster.adoc[]
+include::device_types/RootNode.adoc[]
+include::device_types/BaseDeviceType.adoc[]
+include::app_clusters/test_cluster.adoc[]

--- a/provisional/testdata/base/src/service_device_management/BasicInformationCluster.adoc
+++ b/provisional/testdata/base/src/service_device_management/BasicInformationCluster.adoc
@@ -1,0 +1,25 @@
+[[ref_BasicInformationCluster, Basic Information Cluster]]
+= Basic Information Cluster
+
+== Classification
+
+|===
+| Hierarchy | Role        | Scope    | PICS Code
+| Base      | Application | Endpoint | BIS
+|===
+
+== Cluster Identifiers
+
+[options="header",valign="middle"]
+|===
+| Identification     | Name
+| 0x0028             | Basic Information
+|===
+
+== Revision History
+
+[options="header",valign="middle"]
+|===
+| Revision | Description
+| 1        | Initial Release
+|===

--- a/provisional/testdata/base/src/service_device_management/BridgedDeviceBasicInformationCluster.adoc
+++ b/provisional/testdata/base/src/service_device_management/BridgedDeviceBasicInformationCluster.adoc
@@ -1,0 +1,25 @@
+[[ref_BridgedDeviceBasicInformationCluster, Bridged Device Basic Information Cluster]]
+= Bridged Device Basic Information Cluster
+
+== Classification
+
+|===
+| Hierarchy | Role        | Scope    | PICS Code
+| Base      | Application | Endpoint | BDBIS
+|===
+
+== Cluster Identifiers
+
+[options="header",valign="middle"]
+|===
+| Identification     | Name
+| 0x0039             | Bridged Device Basic Information
+|===
+
+== Revision History
+
+[options="header",valign="middle"]
+|===
+| Revision | Description
+| 1        | Initial Release
+|===

--- a/provisional/testdata/head/src/app_clusters/test_cluster.adoc
+++ b/provisional/testdata/head/src/app_clusters/test_cluster.adoc
@@ -1,0 +1,79 @@
+[[ref_TestCluster, Test Cluster]]
+= Test Cluster
+
+== Classification
+
+|===
+| Hierarchy | Role        | Scope    | PICS Code
+| Base      | Application | Endpoint | TEST
+|===
+
+== Cluster Identifiers
+
+[options="header",valign="middle"]
+|===
+| Identification     | Name
+| 0xFFFE             | Test Cluster
+|===
+
+== Commands
+[options="header",valign="middle"]
+|===
+| ID     | Name              | Direction        | Response      | Access | Conformance
+ifdef::in-progress[]
+| 0x00  s| ProvCommand1      | client => server | Y                 | O      | P
+endif::[]
+| 0x01  s| ProvCommand2      | client => server | Y                 | O      | P
+ifdef::in-progress[]
+| 0x02  s| ProvCommand3      | client => server | Y                 | O      | P
+endif::[]
+ifdef::in-progress[]
+| 0x03  s| NonProvCommand    | client => server | Y                 | O      | M
+endif::[]
+|===
+
+ifdef::in-progress[]
+=== ProvCommand1 Command
+This is Case 1: Provisional in ifdef with no provisional ancestor.
+(The cluster is NOT provisional).
+
+[options="header",valign="middle"]
+|===
+| ID | Name      | Type   | Constraint | Quality | Default | Conformance
+| 0 s| Field1    | string | max 6      |         | empty   | M
+|===
+endif::[]
+
+=== ProvCommand2 Command
+This is Case 2: Provisional not in ifdef.
+(It is in the table without ifdef).
+
+[options="header",valign="middle"]
+|===
+| ID | Name      | Type   | Constraint | Quality | Default | Conformance
+| 0 s| Field2    | string | max 6      |         | empty   | M
+|===
+
+ifdef::in-progress[]
+=== ProvCommand3 Command
+This is Case 3: Provisional in ifdef with provisional ancestor.
+(ProvCommand3 is provisional, and Field3 inside it is also provisional).
+
+[options="header",valign="middle"]
+|===
+| ID | Name      | Type   | Constraint | Quality | Default | Conformance
+| 0 s| Field3    | string | max 6      |         | empty   | P
+|===
+endif::[]
+
+ifdef::in-progress[]
+=== NonProvCommand Command
+This is Case 4: Not provisional in ifdef.
+(Triggers NonProvisional violation).
+
+[options="header",valign="middle"]
+|===
+| ID | Name      | Type   | Constraint | Quality | Default | Conformance
+| 0 s| Field4    | string | max 6      |         | empty   | M
+|===
+endif::[]

--- a/provisional/testdata/head/src/device_types/BaseDeviceType.adoc
+++ b/provisional/testdata/head/src/device_types/BaseDeviceType.adoc
@@ -1,0 +1,16 @@
+[[ref_BaseDeviceType, Base Device Type]]
+= Base Device Type
+
+== Classification
+[options="header",valign="middle"]
+|===
+| Device Name      | Device Type ID | Device Type Revision
+| Base Device Type | 0xFFFE         | 1
+|===
+
+== Cluster Requirements
+[options="header",valign="middle"]
+|===
+| Cluster | Client/Server | Conformance
+| Basic Information | Server | M
+|===

--- a/provisional/testdata/head/src/device_types/RootNode.adoc
+++ b/provisional/testdata/head/src/device_types/RootNode.adoc
@@ -1,0 +1,16 @@
+[[ref_RootNode, Root Node]]
+= Root Node
+
+== Classification
+[options="header",valign="middle"]
+|===
+| Device Name | Device Type ID | Device Type Revision
+| Root Node   | 0x0016         | 1
+|===
+
+== Cluster Requirements
+[options="header",valign="middle"]
+|===
+| Cluster | Client/Server | Conformance
+| Basic Information | Server | M
+|===

--- a/provisional/testdata/head/src/main.adoc
+++ b/provisional/testdata/head/src/main.adoc
@@ -1,0 +1,7 @@
+= Main Spec
+
+include::service_device_management/BasicInformationCluster.adoc[]
+include::service_device_management/BridgedDeviceBasicInformationCluster.adoc[]
+include::device_types/RootNode.adoc[]
+include::device_types/BaseDeviceType.adoc[]
+include::app_clusters/test_cluster.adoc[]

--- a/provisional/testdata/head/src/service_device_management/BasicInformationCluster.adoc
+++ b/provisional/testdata/head/src/service_device_management/BasicInformationCluster.adoc
@@ -1,0 +1,25 @@
+[[ref_BasicInformationCluster, Basic Information Cluster]]
+= Basic Information Cluster
+
+== Classification
+
+|===
+| Hierarchy | Role        | Scope    | PICS Code
+| Base      | Application | Endpoint | BIS
+|===
+
+== Cluster Identifiers
+
+[options="header",valign="middle"]
+|===
+| Identification     | Name
+| 0x0028             | Basic Information
+|===
+
+== Revision History
+
+[options="header",valign="middle"]
+|===
+| Revision | Description
+| 1        | Initial Release
+|===

--- a/provisional/testdata/head/src/service_device_management/BridgedDeviceBasicInformationCluster.adoc
+++ b/provisional/testdata/head/src/service_device_management/BridgedDeviceBasicInformationCluster.adoc
@@ -1,0 +1,25 @@
+[[ref_BridgedDeviceBasicInformationCluster, Bridged Device Basic Information Cluster]]
+= Bridged Device Basic Information Cluster
+
+== Classification
+
+|===
+| Hierarchy | Role        | Scope    | PICS Code
+| Base      | Application | Endpoint | BDBIS
+|===
+
+== Cluster Identifiers
+
+[options="header",valign="middle"]
+|===
+| Identification     | Name
+| 0x0039             | Bridged Device Basic Information
+|===
+
+== Revision History
+
+[options="header",valign="middle"]
+|===
+| Revision | Description
+| 1        | Initial Release
+|===


### PR DESCRIPTION
# Description
This change modifies the violation reporting logic in the `provisional` package. It adds a check to skip reporting violations for an entity if any of its ancestors are marked as provisional.
The goal is to avoid reporting violations for entities that are part of provisional features or clusters, as they may not be subject to full validation rules yet.
## Details
- File: `provisional/compare.go`
- Logic added to walk up the parent chain and check for provisional conformance.
- If a provisional ancestor is found, the violation is skipped.