### PR TITLE
Set normalizeAnchor to true by default

### DIFF
--- a/disco/baller_test.go
+++ b/disco/baller_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"context"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
+	"unsafe"
 
 	"github.com/project-chip/alchemy/asciidoc"
 	"github.com/project-chip/alchemy/asciidoc/parse"
@@ -158,5 +160,79 @@ func TestXrefStyleOnlyInRootWithFile(t *testing.T) {
 		if countAfter != countBefore {
 			t.Errorf("expected number of xrefstyle to remain %d, got %d", countBefore, countAfter)
 		}
+	}
+}
+
+func TestNormalizeAnchorCrossFile(t *testing.T) {
+	pathA := asciidoc.Path{Relative: "testdata/anchor_file.adoc"}
+	inA, err := os.ReadFile("testdata/anchor_file.adoc")
+	if err != nil {
+		t.Fatalf("error reading file A: %v", err)
+	}
+	docA, err := parse.Reader(pathA, bytes.NewReader(inA))
+	if err != nil {
+		t.Fatalf("error parsing file A: %v", err)
+	}
+
+	pathB := asciidoc.Path{Relative: "testdata/reference_file.adoc"}
+	inB, err := os.ReadFile("testdata/reference_file.adoc")
+	if err != nil {
+		t.Fatalf("error reading file B: %v", err)
+	}
+	docB, err := parse.Reader(pathB, bytes.NewReader(inB))
+	if err != nil {
+		t.Fatalf("error parsing file B: %v", err)
+	}
+
+	s := &spec.Specification{}
+	lib := spec.NewLibrary(docA, config.Library{}, nil, nil)
+	lib.Reader = asciidoc.RawReader
+	
+	// Use reflect to set s.libraryIndex
+	v := reflect.ValueOf(s).Elem()
+	f := v.FieldByName("libraryIndex")
+	
+	ptr := unsafe.Pointer(f.UnsafeAddr())
+	mPtr := (*map[*asciidoc.Document]*spec.Library)(ptr)
+	
+	*mPtr = make(map[*asciidoc.Document]*spec.Library)
+	(*mPtr)[docA] = lib
+	(*mPtr)[docB] = lib
+
+	an := AnchorNormalizer{
+		spec:    s,
+		options: DiscoOptions{NormalizeAnchors: true},
+	}
+	
+	_, err = lib.Anchors(asciidoc.RawReader)
+	if err != nil {
+		t.Fatalf("error indexing anchors: %v", err)
+	}
+	
+	// Run it on docB
+	an.rewriteCrossReferences(docB)
+	
+	// Verify that docB retains its label!
+	var foundXref *asciidoc.CrossReference
+	parse.Search(docB, asciidoc.RawReader, nil, docB.Children(), func(doc *asciidoc.Document, el asciidoc.Element, parent asciidoc.ParentElement, index int) parse.SearchShould {
+		if xref, ok := el.(*asciidoc.CrossReference); ok {
+			foundXref = xref
+			return parse.SearchShouldStop
+		}
+		return parse.SearchShouldContinue
+	})
+	
+	if foundXref == nil {
+		t.Fatal("expected to find cross reference in docB")
+	}
+	
+	if len(foundXref.Elements) == 0 {
+		t.Error("expected reference to retain its label, but it was removed")
+	}
+	
+	label := labelText(foundXref.Elements)
+	expectedLabel := "A Non-Normalized Replacement Text Different Than Section Name"
+	if label != expectedLabel {
+		t.Errorf("expected label %q, got %q", expectedLabel, label)
 	}
 }

--- a/disco/option.go
+++ b/disco/option.go
@@ -19,7 +19,7 @@ type DiscoOptions struct {
 	RemoveExtraSpaces             bool `default:"true" aliases:"removeExtraSpaces" help:"remove extraneous spaces" group:"Discoballing:"`
 	NormalizeFeatureNames         bool `default:"true" aliases:"normalizeFeatureNames" help:"correct invalid feature names" group:"Discoballing:"`
 	DisambiguateConformanceChoice bool `default:"true" aliases:"disambiguateConformanceChoice" help:"ensure conformance choices are only used once per document" group:"Discoballing:"`
-	NormalizeAnchors              bool `default:"false" aliases:"normalizeAnchors" help:"rewrite anchors and references without labels" group:"Discoballing:"`
+	NormalizeAnchors              bool `default:"true" aliases:"normalizeAnchors" help:"rewrite anchors and references without labels" group:"Discoballing:"`
 	RemoveMandatoryFallbacks      bool `default:"true" aliases:"removeMandatoryFallbacks" help:"remove fallback values for mandatory fields" group:"Discoballing:"`
 	RenameSections                bool `default:"false" help:"rename sections to disco-ball standard names" group:"Discoballing:"`
 	XrefStyleOnlyInRoot           bool `default:"true" aliases:"xrefStyleOnlyInRoot" help:"enforce xrefstyle: basic only in root" group:"Discoballing:"`
@@ -42,7 +42,7 @@ var DefaultOptions = DiscoOptions{
 	RemoveExtraSpaces:             true,
 	NormalizeFeatureNames:         true,
 	DisambiguateConformanceChoice: true,
-	NormalizeAnchors:              false,
+	NormalizeAnchors:              true,
 	RemoveMandatoryFallbacks:      true,
 	RenameSections:                false,
 	XrefStyleOnlyInRoot:           true,

--- a/disco/references.go
+++ b/disco/references.go
@@ -53,11 +53,19 @@ func (an AnchorNormalizer) rewriteCrossReferences(doc *asciidoc.Document) {
 			}
 			continue
 		}
-		anchorLabel := labelText(anchor.LabelElements)
+		var anchorLabel string
+		if an.options.NormalizeAnchors {
+			if _, isSection := anchor.Element.(*asciidoc.Section); isSection {
+				anchorLabel = library.SectionName(anchor.Element.(*asciidoc.Section))
+			}
+		}
 		if anchorLabel == "" {
-			section, isSection := anchor.Element.(*asciidoc.Section)
-			if isSection {
-				anchorLabel = library.SectionName(section)
+			anchorLabel = labelText(anchor.LabelElements)
+			if anchorLabel == "" {
+				section, isSection := anchor.Element.(*asciidoc.Section)
+				if isSection {
+					anchorLabel = library.SectionName(section)
+				}
 			}
 		}
 		// We're going to be modifying the underlying array, so we need to make a copy of the slice

--- a/disco/references.go
+++ b/disco/references.go
@@ -54,18 +54,14 @@ func (an AnchorNormalizer) rewriteCrossReferences(doc *asciidoc.Document) {
 			continue
 		}
 		var anchorLabel string
-		if an.options.NormalizeAnchors {
-			if _, isSection := anchor.Element.(*asciidoc.Section); isSection {
-				anchorLabel = library.SectionName(anchor.Element.(*asciidoc.Section))
-			}
+		section, isSection := anchor.Element.(*asciidoc.Section)
+		if an.options.NormalizeAnchors && isSection {
+			anchorLabel = library.SectionName(section)
 		}
 		if anchorLabel == "" {
 			anchorLabel = labelText(anchor.LabelElements)
-			if anchorLabel == "" {
-				section, isSection := anchor.Element.(*asciidoc.Section)
-				if isSection {
-					anchorLabel = library.SectionName(section)
-				}
+			if anchorLabel == "" && isSection {
+				anchorLabel = library.SectionName(section)
 			}
 		}
 		// We're going to be modifying the underlying array, so we need to make a copy of the slice

--- a/disco/references.go
+++ b/disco/references.go
@@ -96,6 +96,9 @@ func (an AnchorNormalizer) rewriteCrossReferences(doc *asciidoc.Document) {
 }
 
 func removeCrossReferenceStutter(library *spec.Library, doc *asciidoc.Document, icr *asciidoc.CrossReference, parent asciidoc.Parent, index int) {
+	if parent == nil {
+		return
+	}
 	if len(icr.Elements) > 0 {
 		return
 	}

--- a/disco/testdata/anchor_file.adoc
+++ b/disco/testdata/anchor_file.adoc
@@ -1,0 +1,2 @@
+[[ref_external_anchor, A Non-Normalized Replacement Text Different Than Section Name]]
+== Section Name Different Than Replacement Text

--- a/disco/testdata/reference_file.adoc
+++ b/disco/testdata/reference_file.adoc
@@ -1,0 +1,1 @@
+This is a reference to <<ref_external_anchor, A Non-Normalized Replacement Text Different Than Section Name>>.


### PR DESCRIPTION
Update Alchemy baller to normalize anchors by default:

- Set NormalizeAnchor to true by default
- Fix a panic
- If NormalizeAnchor is set, when discoballing references, the normalized anchor will be considered even for external files, without necessarily suggesting fix on them.