### PR TITLE
Add support for custom errata YAML using errata-path CLI argument

### DIFF
--- a/errata/load.go
+++ b/errata/load.go
@@ -16,8 +16,8 @@ import (
 //go:embed default.yaml
 var defaultErrata []byte
 
-func LoadErrata(config *config.Config) (*Collection, error) {
-	b := loadErrataFile(config.Root())
+func LoadErrata(config *config.Config, errataPath string) (*Collection, error) {
+	b := loadErrataFile(config.Root(), errataPath)
 	if b == nil {
 		b = defaultErrata
 	}
@@ -82,11 +82,16 @@ type overlayErrata struct {
 	ZAP      *SDK      `yaml:"zap,omitempty"`
 }
 
-func loadErrataFile(specRoot string) []byte {
-	if specRoot == "" {
-		return nil
+func loadErrataFile(specRoot string, overridePath string) []byte {
+	var errataPath string
+	if overridePath != "" {
+		errataPath = overridePath
+	} else {
+		if specRoot == "" {
+			return nil
+		}
+		errataPath = filepath.Join(specRoot, ".github/alchemy/errata.yaml")
 	}
-	errataPath := filepath.Join(specRoot, ".github/alchemy/errata.yaml")
 	exists, err := files.Exists(errataPath)
 	if err != nil {
 		slog.Warn("error checking for errata path", slog.Any("error", err))

--- a/matter/spec/option.go
+++ b/matter/spec/option.go
@@ -31,7 +31,8 @@ func (bo BuilderOptions) List() (options []BuilderOption) {
 }
 
 type ParserOptions struct {
-	Root string `name:"spec-root" default:"connectedhomeip-spec" aliases:"specRoot" help:"the src root of your clone of CHIP-Specifications/connectedhomeip-spec"  group:"Spec:"`
+	Root       string `name:"spec-root" default:"connectedhomeip-spec" aliases:"specRoot" help:"the src root of your clone of CHIP-Specifications/connectedhomeip-spec" group:"Spec:"`
+	ErrataPath string `name:"errata-path" help:"the path to the errata file" group:"Spec:"`
 }
 
 func (po *ParserOptions) AfterApply() error {
@@ -48,6 +49,12 @@ func (po *ParserOptions) AfterApply() error {
 	}
 	if !exists {
 		return fmt.Errorf("spec root \"%s\" does not exist", po.Root)
+	}
+	if po.ErrataPath != "" && !filepath.IsAbs(po.ErrataPath) {
+		po.ErrataPath, err = filepath.Abs(po.ErrataPath)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/matter/spec/option.go
+++ b/matter/spec/option.go
@@ -50,10 +50,19 @@ func (po *ParserOptions) AfterApply() error {
 	if !exists {
 		return fmt.Errorf("spec root \"%s\" does not exist", po.Root)
 	}
-	if po.ErrataPath != "" && !filepath.IsAbs(po.ErrataPath) {
-		po.ErrataPath, err = filepath.Abs(po.ErrataPath)
+	if po.ErrataPath != "" {
+		if !filepath.IsAbs(po.ErrataPath) {
+			po.ErrataPath, err = filepath.Abs(po.ErrataPath)
+			if err != nil {
+				return err
+			}
+		}
+		exists, err = files.Exists(po.ErrataPath)
 		if err != nil {
 			return err
+		}
+		if !exists {
+			return fmt.Errorf("errata path \"%s\" does not exist", po.ErrataPath)
 		}
 	}
 	return nil

--- a/matter/spec/pipeline.go
+++ b/matter/spec/pipeline.go
@@ -29,7 +29,7 @@ func Build(cxt context.Context, parserOptions ParserOptions, processingOptions p
 	}
 
 	var ec *errata.Collection
-	ec, err = errata.LoadErrata(cfg)
+	ec, err = errata.LoadErrata(cfg, parserOptions.ErrataPath)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
## Description
This change allows users to specify a custom path to an errata YAML file via the `--errata-path` command-line option.

Previously, the system looked for `errata.yaml` exclusively at the fixed location `.github/alchemy/errata.yaml` within the spec root directory. With this change, if `--errata-path` is provided, it will load the errata from that specific file instead. If the argument is not provided, it falls back to the previous behavior of checking the spec root and then falling back to the embedded default errata.

## Changes

### errata/load.go
- Updated `LoadErrata` and `loadErrataFile` to accept an optional `errataPath` parameter.
- Implemented logic to use the provided path if non-empty, skipping the default path construction.

### matter/spec/option.go
- Added `ErrataPath` string field to `ParserOptions` struct with `errata-path` tag.
- Added logic in `AfterApply` to convert the provided `ErrataPath` to an absolute path for consistency.

### matter/spec/pipeline.go
- Updated the pipeline to pass `parserOptions.ErrataPath` to `errata.LoadErrata`.