### PR TITLE
Add strip-comments CLI command

### DIFF
--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -23,9 +23,10 @@ var commands struct {
 	Provisional cli.Provisional `cmd:"" name:"provisional" hidden:"" group:"Provisional:"`
 	Validate    cli.Validate    `cmd:"" help:"validate the Matter specification object model" group:"Spec Commands:"`
 	Yaml2Python cli.Yaml2Python `cmd:"" name:"yaml-2-python" aliases:"yaml2python" help:"create a shell python script from a test YAML, optionally filtered to the files specified by filename_pattern"  group:"Testing Commands:"`
-	Wordlist    cli.Wordlist    `cmd:"" hidden:"" name:"wordlist" help:"add words to wordlist.txt"`
-	ErrDiff     cli.ErrDiff     `cmd:"" name:"err-diff" hidden:"" help:"Checks for new errors caused by a PR in review."`
-	Version     Version         `cmd:"" hidden:"" name:"version" help:"display version number"`
+	Wordlist      cli.Wordlist      `cmd:"" hidden:"" name:"wordlist" help:"add words to wordlist.txt"`
+	StripComments cli.StripComments `cmd:"" hidden:"" name:"strip-comments" help:"removes comments from a file"`
+	ErrDiff       cli.ErrDiff       `cmd:"" name:"err-diff" hidden:"" help:"Checks for new errors caused by a PR in review."`
+	Version       Version           `cmd:"" hidden:"" name:"version" help:"display version number"`
 
 	globalFlags `embed:""`
 }

--- a/cmd/cli/comments.go
+++ b/cmd/cli/comments.go
@@ -1,0 +1,61 @@
+package cli
+
+import (
+	"context"
+
+	"github.com/project-chip/alchemy/internal/files"
+	"github.com/project-chip/alchemy/internal/paths"
+	"github.com/project-chip/alchemy/internal/pipeline"
+	"github.com/project-chip/alchemy/internal/text"
+)
+
+type StripComments struct {
+	pipeline.ProcessingOptions `embed:""`
+	files.OutputOptions        `embed:""`
+
+	Paths []string `arg:"" help:"Paths of files to strip comments from" required:""`
+}
+
+func (f *StripComments) Run(cc *Context) (err error) {
+	var inputs pipeline.Paths
+
+	inputs, err = pipeline.Start(cc, paths.NewTargeter(f.Paths...))
+
+	if err != nil {
+		return err
+	}
+
+	reader := files.NewReader("Reading files...")
+
+	var textFiles pipeline.FileSet
+	textFiles, err = pipeline.Parallel(cc, f.ProcessingOptions, reader, inputs)
+
+	if err != nil {
+		return err
+	}
+
+	cr := &commentRemover{}
+
+	var strippedFiles pipeline.FileSet
+	strippedFiles, err = pipeline.Parallel(cc, f.ProcessingOptions, cr, textFiles)
+
+	if err != nil {
+		return err
+	}
+	writer := files.NewWriter[[]byte]("Writing files...", f.OutputOptions)
+	err = writer.Write(cc, strippedFiles, f.ProcessingOptions)
+	return
+}
+
+type commentRemover struct {
+}
+
+func (p commentRemover) Name() string {
+	return "Removing comments"
+}
+
+func (p commentRemover) Process(cxt context.Context, input *pipeline.Data[[]byte], index int32, total int32) (outputs []*pipeline.Data[[]byte], extra []*pipeline.Data[[]byte], err error) {
+	output := text.RemoveComments(string(input.Content))
+	outputs = append(outputs, &pipeline.Data[[]byte]{Path: input.Path, Content: []byte(output)})
+	return
+}


### PR DESCRIPTION
## Description

This PR introduces a new `strip-comments` CLI command to the alchemy tool suite. The command allows users to strip single-line (`//`) and block (`/* ... */`) comments from target files using the internal pipeline processor.

### Changes

- Added a new pipeline processor class in cmd/cli/comments.go defining the StripComments task structure and options.
- Registered the strip-comments subcommand within the main command line interface parser in cmd/cli.go.
- Leveraged the existing text.RemoveComments package utility to perform the comment extraction on loaded buffer inputs.
