### PR TITLE
Implement errata overlay and priority merging

### DIFF
--- a/errata/load.go
+++ b/errata/load.go
@@ -16,11 +16,88 @@ import (
 //go:embed default.yaml
 var defaultErrata []byte
 
-func LoadErrata(config *config.Config, errataPath string) (*Collection, error) {
-	b := loadErrataFile(config.Root(), errataPath)
-	if b == nil {
-		b = defaultErrata
+func LoadErrata(config *config.Config, errataPath string, errataOverlayPath string) (*Collection, error) {
+	var mainCollection *Collection
+
+	var targetPath string
+	if errataPath != "" {
+		targetPath = errataPath
+	} else {
+		if config.Root() == "" {
+			mainCollection = &Collection{errata: make(map[string]*Errata)}
+		} else {
+			targetPath = filepath.Join(config.Root(), ".github/alchemy/errata.yaml")
+		}
 	}
+
+	if mainCollection == nil {
+		exists, err := files.Exists(targetPath)
+		if err != nil {
+			slog.Warn("error checking for errata path", slog.Any("error", err))
+			return nil, err
+		}
+
+		if !exists {
+			if errataPath != "" {
+				return nil, fmt.Errorf("errata path %s does not exist", errataPath)
+			}
+			mainCollection, err = parseErrataBytes(defaultErrata)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			mainCollection, err = loadSingleErrataFile(targetPath)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	if errataOverlayPath != "" {
+		exists, err := files.Exists(errataOverlayPath)
+		if err != nil {
+			return nil, fmt.Errorf("error checking errata overlay path: %w", err)
+		}
+		if !exists {
+			return nil, fmt.Errorf("errata overlay path %s does not exist", errataOverlayPath)
+		}
+		overlayCollection, err := loadSingleErrataFile(errataOverlayPath)
+		if err != nil {
+			return nil, fmt.Errorf("error loading errata overlay: %w", err)
+		}
+
+		for path, oe := range overlayCollection.errata {
+			if existing, ok := mainCollection.errata[path]; ok {
+				existing.Merge(oe)
+			} else {
+				mainCollection.errata[path] = oe
+			}
+		}
+	}
+
+	for p := range mainCollection.errata {
+		path := filepath.Join(config.Root(), p)
+		exists, err := files.Exists(path)
+		if err != nil {
+			slog.Error("error checking if file exists", slog.Any("error", err))
+		}
+		if !exists {
+			slog.Warn("errata points to non-existent file", "path", p)
+		}
+	}
+
+	return mainCollection, nil
+}
+
+func loadSingleErrataFile(path string) (*Collection, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("error reading errata path %s: %w", path, err)
+	}
+	return parseErrataBytes(b)
+}
+
+func parseErrataBytes(b []byte) (*Collection, error) {
 	var errataOverlay errataOverlay
 	err := yaml.Unmarshal(b, &errataOverlay)
 	if err != nil {
@@ -31,8 +108,6 @@ func LoadErrata(config *config.Config, errataPath string) (*Collection, error) {
 	if err != nil {
 		return nil, err
 	}
-	// TODO: once alchemy has migrated to using sdk: instead of zap: in errata.yaml, we can drop this indirection
-	// This is only here because YAML can't have two tags aliasing the same value
 	overlayErrata := make(map[string]*Errata)
 	for path, oe := range errataOverlay.Errata {
 		var e Errata
@@ -52,26 +127,12 @@ func LoadErrata(config *config.Config, errataPath string) (*Collection, error) {
 		}
 		overlayErrata[path] = &e
 	}
-	c := &Collection{errata: overlayErrata}
-
-	for p := range c.errata {
-		path := filepath.Join(config.Root(), p)
-		exists, err := files.Exists(path)
-		if err != nil {
-			slog.Error("error checking if file exists", slog.Any("error", err))
-		}
-		if !exists {
-			slog.Warn("errata points to non-existent file", "path", p)
-		}
-
-	}
-
-	return c, nil
+	return &Collection{errata: overlayErrata}, nil
 }
 
 type errataOverlay struct {
-	MinimumVersion string                    `yaml:"minimum-version"`
-	Errata         map[string]*overlayErrata `yaml:"errata"`
+	MinimumVersion string                    `yaml:"minimum-version,omitempty"`
+	Errata         map[string]*overlayErrata `yaml:"errata,omitempty"`
 }
 
 type overlayErrata struct {

--- a/errata/load_test.go
+++ b/errata/load_test.go
@@ -1,0 +1,200 @@
+package errata
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/project-chip/alchemy/config"
+)
+
+func TestLoadErrataWithOverlay(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	mainErrataContent := `
+errata:
+  app_clusters/SomeCluster.adoc:
+    sdk:
+      cluster-name: "OriginalName"
+      type-names:
+        OldType: "NewType"
+`
+	overlayErrataContent := `
+errata:
+  app_clusters/SomeCluster.adoc:
+    sdk:
+      cluster-name: "OverlayName"
+      type-names:
+        OverlayOld: "OverlayNew"
+        OldType: "OverriddenType"
+`
+
+	mainPath := filepath.Join(tmpDir, "main_errata.yaml")
+	overlayPath := filepath.Join(tmpDir, "overlay_errata.yaml")
+
+	if err := os.WriteFile(mainPath, []byte(mainErrataContent), 0644); err != nil {
+		t.Fatalf("failed to write main errata: %v", err)
+	}
+
+	if err := os.WriteFile(overlayPath, []byte(overlayErrataContent), 0644); err != nil {
+		t.Fatalf("failed to write overlay errata: %v", err)
+	}
+
+	// Create a fake config with root pointing to tmpDir
+	cfg := &config.Config{}
+
+	col, err := LoadErrata(cfg, mainPath, overlayPath)
+	if err != nil {
+		t.Fatalf("LoadErrata failed: %v", err)
+	}
+
+	e := col.Get("app_clusters/SomeCluster.adoc")
+	if e == nil {
+		t.Fatalf("expected errata for app_clusters/SomeCluster.adoc, got nil")
+	}
+
+	// Verify overriden fields with overlay higher priority
+	if e.SDK.ClusterName != "OverlayName" {
+		t.Errorf("expected ClusterName to be 'OverlayName', got '%s'", e.SDK.ClusterName)
+	}
+
+	if val, ok := e.SDK.TypeNames["OldType"]; !ok || val != "OverriddenType" {
+		t.Errorf("expected OldType to be 'OverriddenType', got '%s'", val)
+	}
+
+	if val, ok := e.SDK.TypeNames["OverlayOld"]; !ok || val != "OverlayNew" {
+		t.Errorf("expected OverlayOld to be 'OverlayNew', got '%s'", val)
+	}
+}
+
+func TestLoadErrataSDKTypesMerge(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	mainErrataContent := `
+errata:
+  app_clusters/SomeCluster.adoc:
+    sdk:
+      types:
+        attributes:
+          SomeAttribute:
+            override-name: "MainOverride"
+            conformance: "O"
+            access: "read"
+            fields:
+              - name: "FieldA"
+                type: "int"
+        commands:
+          SomeCommand:
+            conformance: "M"
+      extra-types:
+        structs:
+          SomeExtraStruct:
+            name: "MainExtraStruct"
+`
+	overlayErrataContent := `
+errata:
+  app_clusters/SomeCluster.adoc:
+    sdk:
+      types:
+        attributes:
+          SomeAttribute:
+            override-name: "OverlayOverride"
+            conformance: "M"
+            fields:
+              - name: "FieldA"
+                type: "string"
+              - name: "FieldB"
+                type: "bool"
+          AnotherAttribute:
+            conformance: "D"
+        commands:
+          SomeCommand:
+            conformance: "O"
+            response: "SomeResponse"
+      extra-types:
+        structs:
+          SomeExtraStruct:
+            name: "OverlayExtraStruct"
+            override-name: "OverlayExtraOverride"
+`
+
+	mainPath := filepath.Join(tmpDir, "main_errata.yaml")
+	overlayPath := filepath.Join(tmpDir, "overlay_errata.yaml")
+
+	if err := os.WriteFile(mainPath, []byte(mainErrataContent), 0644); err != nil {
+		t.Fatalf("failed to write main errata: %v", err)
+	}
+
+	if err := os.WriteFile(overlayPath, []byte(overlayErrataContent), 0644); err != nil {
+		t.Fatalf("failed to write overlay errata: %v", err)
+	}
+
+	cfg := &config.Config{}
+
+	col, err := LoadErrata(cfg, mainPath, overlayPath)
+	if err != nil {
+		t.Fatalf("LoadErrata failed: %v", err)
+	}
+
+	e := col.Get("app_clusters/SomeCluster.adoc")
+	if e == nil {
+		t.Fatalf("expected errata, got nil")
+	}
+
+	// 1. Verify types.attributes["SomeAttribute"] merge
+	someAttr, ok := e.SDK.Types.Attributes["SomeAttribute"]
+	if !ok {
+		t.Fatalf("expected SomeAttribute to exist in attributes")
+	}
+	if someAttr.OverrideName != "OverlayOverride" {
+		t.Errorf("expected override-name to be 'OverlayOverride', got '%s'", someAttr.OverrideName)
+	}
+	if someAttr.Conformance != "M" {
+		t.Errorf("expected conformance to be 'M', got '%s'", someAttr.Conformance)
+	}
+	if someAttr.Access != "read" {
+		t.Errorf("expected access to be retained as 'read', got '%s'", someAttr.Access)
+	}
+	if len(someAttr.Fields) != 2 {
+		t.Fatalf("expected 2 fields, got %d", len(someAttr.Fields))
+	}
+	if someAttr.Fields[0].Name != "FieldA" || someAttr.Fields[0].Type != "string" {
+		t.Errorf("expected field 0 to be FieldA/string, got %s/%s", someAttr.Fields[0].Name, someAttr.Fields[0].Type)
+	}
+	if someAttr.Fields[1].Name != "FieldB" || someAttr.Fields[1].Type != "bool" {
+		t.Errorf("expected field 1 to be FieldB/bool, got %s/%s", someAttr.Fields[1].Name, someAttr.Fields[1].Type)
+	}
+
+	// 2. Verify types.attributes["AnotherAttribute"] creation
+	anotherAttr, ok := e.SDK.Types.Attributes["AnotherAttribute"]
+	if !ok {
+		t.Fatalf("expected AnotherAttribute to exist")
+	}
+	if anotherAttr.Conformance != "D" {
+		t.Errorf("expected conformance to be 'D', got '%s'", anotherAttr.Conformance)
+	}
+
+	// 3. Verify types.commands["SomeCommand"] merge
+	someCmd, ok := e.SDK.Types.Commands["SomeCommand"]
+	if !ok {
+		t.Fatalf("expected SomeCommand to exist")
+	}
+	if someCmd.Conformance != "O" {
+		t.Errorf("expected conformance to be 'O', got '%s'", someCmd.Conformance)
+	}
+	if someCmd.Response != "SomeResponse" {
+		t.Errorf("expected response to be 'SomeResponse', got '%s'", someCmd.Response)
+	}
+
+	// 4. Verify extra-types.structs["SomeExtraStruct"] merge
+	extraStruct, ok := e.SDK.ExtraTypes.Structs["SomeExtraStruct"]
+	if !ok {
+		t.Fatalf("expected SomeExtraStruct to exist")
+	}
+	if extraStruct.Name != "OverlayExtraStruct" {
+		t.Errorf("expected name to be 'OverlayExtraStruct', got '%s'", extraStruct.Name)
+	}
+	if extraStruct.OverrideName != "OverlayExtraOverride" {
+		t.Errorf("expected override-name to be 'OverlayExtraOverride', got '%s'", extraStruct.OverrideName)
+	}
+}

--- a/errata/merge.go
+++ b/errata/merge.go
@@ -176,9 +176,15 @@ func (s *SDK) Merge(other *SDK) {
 	}
 }
 
-func (u UniqueStringList) Merge(other UniqueStringList) {
+func (u *UniqueStringList) Merge(other UniqueStringList) {
+	if len(other) == 0 {
+		return
+	}
+	if *u == nil {
+		*u = make(UniqueStringList)
+	}
 	for k := range other {
-		u[k] = struct{}{}
+		(*u)[k] = struct{}{}
 	}
 }
 

--- a/errata/merge.go
+++ b/errata/merge.go
@@ -1,0 +1,304 @@
+package errata
+
+import "slices"
+
+func (e *Errata) Merge(other *Errata) {
+	if other == nil {
+		return
+	}
+	e.Disco.Merge(&other.Disco)
+	e.Spec.Merge(&other.Spec)
+	e.TestPlan.Merge(&other.TestPlan)
+	e.SDK.Merge(&other.SDK)
+}
+
+func (d *Disco) Merge(other *Disco) {
+	if other == nil {
+		return
+	}
+	if d.Sections == nil {
+		d.Sections = make(map[string]DiscoSection)
+	}
+	for k, v := range other.Sections {
+		if s, ok := d.Sections[k]; ok {
+			s.Merge(&v)
+			d.Sections[k] = s
+		} else {
+			d.Sections[k] = v
+		}
+	}
+}
+
+func (ds *DiscoSection) Merge(other *DiscoSection) {
+	if other == nil {
+		return
+	}
+	if other.Skip != DiscoPurposeNone {
+		ds.Skip = other.Skip
+	}
+}
+
+func (s *Spec) Merge(other *Spec) {
+	if other == nil {
+		return
+	}
+	if other.UtilityInclude {
+		s.UtilityInclude = true
+	}
+	if other.Domain != "" {
+		s.Domain = other.Domain
+	}
+	if s.Sections == nil {
+		s.Sections = make(map[string]SpecSection)
+	}
+	for k, v := range other.Sections {
+		if ss, ok := s.Sections[k]; ok {
+			ss.Merge(&v)
+			s.Sections[k] = ss
+		} else {
+			s.Sections[k] = v
+		}
+	}
+}
+
+func (ss *SpecSection) Merge(other *SpecSection) {
+	if other == nil {
+		return
+	}
+	if other.Skip != SpecPurposeNone {
+		ss.Skip = other.Skip
+	}
+}
+
+func (tp *TestPlan) Merge(other *TestPlan) {
+	if other == nil {
+		return
+	}
+	if other.TestPlanPath != "" {
+		tp.TestPlanPath = other.TestPlanPath
+	}
+	if tp.TestPlanPaths == nil {
+		tp.TestPlanPaths = make(map[string]TestPlanPath)
+	}
+	for k, v := range other.TestPlanPaths {
+		if existing, ok := tp.TestPlanPaths[k]; ok {
+			if v.Path != "" {
+				existing.Path = v.Path
+			}
+			tp.TestPlanPaths[k] = existing
+		} else {
+			tp.TestPlanPaths[k] = v
+		}
+	}
+}
+
+func (s *SDK) Merge(other *SDK) {
+	if other == nil {
+		return
+	}
+	if other.SkipFile {
+		s.SkipFile = true
+	}
+	if other.SuppressAttributePermissions {
+		s.SuppressAttributePermissions = true
+	}
+	if other.ClusterDefinePrefix != "" {
+		s.ClusterDefinePrefix = other.ClusterDefinePrefix
+	}
+	if other.SuppressClusterDefinePrefix {
+		s.SuppressClusterDefinePrefix = true
+	}
+	if s.DefineOverrides == nil {
+		s.DefineOverrides = make(map[string]string)
+	}
+	for k, v := range other.DefineOverrides {
+		s.DefineOverrides[k] = v
+	}
+	if other.ClusterName != "" {
+		s.ClusterName = other.ClusterName
+	}
+	if s.ClusterAliases == nil {
+		s.ClusterAliases = make(map[string][]string)
+	}
+	for k, v := range other.ClusterAliases {
+		s.ClusterAliases[k] = v
+	}
+	if s.ClusterListKeys == nil {
+		s.ClusterListKeys = make(map[string]string)
+	}
+	for k, v := range other.ClusterListKeys {
+		s.ClusterListKeys[k] = v
+	}
+	if other.WritePrivilegeAsRole {
+		s.WritePrivilegeAsRole = true
+	}
+
+	s.SeparateStructs.Merge(other.SeparateStructs)
+	s.SeparateBitmaps.Merge(other.SeparateBitmaps)
+	s.SeparateEnums.Merge(other.SeparateEnums)
+
+	s.SharedBitmaps.Merge(other.SharedBitmaps)
+	s.SharedEnums.Merge(other.SharedEnums)
+	s.SharedStructs.Merge(other.SharedStructs)
+
+	if other.TemplatePath != "" {
+		s.TemplatePath = other.TemplatePath
+	}
+	if s.ClusterSplit == nil {
+		s.ClusterSplit = make(map[string]string)
+	}
+	for k, v := range other.ClusterSplit {
+		s.ClusterSplit[k] = v
+	}
+	for _, v := range other.ClusterSkip {
+		if !slices.Contains(s.ClusterSkip, v) {
+			s.ClusterSkip = append(s.ClusterSkip, v)
+		}
+	}
+	if s.TypeNames == nil {
+		s.TypeNames = make(map[string]string)
+	}
+	for k, v := range other.TypeNames {
+		s.TypeNames[k] = v
+	}
+
+	if other.Types != nil {
+		if s.Types == nil {
+			s.Types = &SDKTypes{}
+		}
+		s.Types.Merge(other.Types)
+	}
+	if other.ExtraTypes != nil {
+		if s.ExtraTypes == nil {
+			s.ExtraTypes = &SDKTypes{}
+		}
+		s.ExtraTypes.Merge(other.ExtraTypes)
+	}
+}
+
+func (u UniqueStringList) Merge(other UniqueStringList) {
+	for k := range other {
+		u[k] = struct{}{}
+	}
+}
+
+func (st *SDKTypes) Merge(other *SDKTypes) {
+	if other == nil {
+		return
+	}
+	st.Attributes = mergeSDKTypeMap(st.Attributes, other.Attributes)
+	st.Clusters = mergeSDKTypeMap(st.Clusters, other.Clusters)
+	st.Enums = mergeSDKTypeMap(st.Enums, other.Enums)
+	st.Bitmaps = mergeSDKTypeMap(st.Bitmaps, other.Bitmaps)
+	st.Structs = mergeSDKTypeMap(st.Structs, other.Structs)
+	st.Commands = mergeSDKTypeMap(st.Commands, other.Commands)
+	st.Events = mergeSDKTypeMap(st.Events, other.Events)
+	st.DeviceTypes = mergeSDKTypeMap(st.DeviceTypes, other.DeviceTypes)
+}
+
+func mergeSDKTypeMap(target, source map[string]*SDKType) map[string]*SDKType {
+	if source == nil {
+		return target
+	}
+	if target == nil {
+		target = make(map[string]*SDKType)
+	}
+	for k, v := range source {
+		if t, ok := target[k]; ok {
+			t.Merge(v)
+		} else {
+			target[k] = v
+		}
+	}
+	return target
+}
+
+func (t *SDKType) Merge(other *SDKType) {
+	if other == nil {
+		return
+	}
+	if other.Type != "" {
+		t.Type = other.Type
+	}
+	if other.Name != "" {
+		t.Name = other.Name
+	}
+	if other.OverrideName != "" {
+		t.OverrideName = other.OverrideName
+	}
+	if other.OverrideType != "" {
+		t.OverrideType = other.OverrideType
+	}
+	if other.List {
+		t.List = true
+	}
+	t.Fields = mergeSDKTypeList(t.Fields, other.Fields)
+	t.ExtraFields = mergeSDKTypeList(t.ExtraFields, other.ExtraFields)
+	if other.Domain != "" {
+		t.Domain = other.Domain
+	}
+	if other.Priority != "" {
+		t.Priority = other.Priority
+	}
+	if other.Description != "" {
+		t.Description = other.Description
+	}
+	if other.Bit != "" {
+		t.Bit = other.Bit
+	}
+	if other.Code != "" {
+		t.Code = other.Code
+	}
+	if other.Value != "" {
+		t.Value = other.Value
+	}
+	if other.Constraint != "" {
+		t.Constraint = other.Constraint
+	}
+	if other.Conformance != "" {
+		t.Conformance = other.Conformance
+	}
+	if other.Fallback != "" {
+		t.Fallback = other.Fallback
+	}
+	if other.Quality != "" {
+		t.Quality = other.Quality
+	}
+	if other.Access != "" {
+		t.Access = other.Access
+	}
+	if other.Direction != "" {
+		t.Direction = other.Direction
+	}
+	if other.Response != "" {
+		t.Response = other.Response
+	}
+	if other.FabricScoping != "" {
+		t.FabricScoping = other.FabricScoping
+	}
+	if other.FabricSensitivity != "" {
+		t.FabricSensitivity = other.FabricSensitivity
+	}
+	t.Attributes = mergeSDKTypeMap(t.Attributes, other.Attributes)
+	t.Commands = mergeSDKTypeMap(t.Commands, other.Commands)
+}
+
+func mergeSDKTypeList(target, source []*SDKType) []*SDKType {
+	if len(source) == 0 {
+		return target
+	}
+	for _, s := range source {
+		found := false
+		for _, t := range target {
+			if t.Name == s.Name {
+				t.Merge(s)
+				found = true
+				break
+			}
+		}
+		if !found {
+			target = append(target, s)
+		}
+	}
+	return target
+}

--- a/matter/spec/option.go
+++ b/matter/spec/option.go
@@ -31,8 +31,9 @@ func (bo BuilderOptions) List() (options []BuilderOption) {
 }
 
 type ParserOptions struct {
-	Root       string `name:"spec-root" default:"connectedhomeip-spec" aliases:"specRoot" help:"the src root of your clone of CHIP-Specifications/connectedhomeip-spec" group:"Spec:"`
-	ErrataPath string `name:"errata-path" help:"the path to the errata file" group:"Spec:"`
+	Root              string `name:"spec-root" default:"connectedhomeip-spec" aliases:"specRoot" help:"the src root of your clone of CHIP-Specifications/connectedhomeip-spec" group:"Spec:"`
+	ErrataPath        string `name:"errata-path" help:"the path to the errata file" group:"Spec:"`
+	ErrataOverlayPath string `name:"errata-overlay" help:"the path to the errata overlay file" group:"Spec:"`
 }
 
 func (po *ParserOptions) AfterApply() error {
@@ -63,6 +64,21 @@ func (po *ParserOptions) AfterApply() error {
 		}
 		if !exists {
 			return fmt.Errorf("errata path \"%s\" does not exist", po.ErrataPath)
+		}
+	}
+	if po.ErrataOverlayPath != "" {
+		if !filepath.IsAbs(po.ErrataOverlayPath) {
+			po.ErrataOverlayPath, err = filepath.Abs(po.ErrataOverlayPath)
+			if err != nil {
+				return err
+			}
+		}
+		exists, err = files.Exists(po.ErrataOverlayPath)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return fmt.Errorf("errata overlay path \"%s\" does not exist", po.ErrataOverlayPath)
 		}
 	}
 	return nil

--- a/matter/spec/pipeline.go
+++ b/matter/spec/pipeline.go
@@ -29,7 +29,7 @@ func Build(cxt context.Context, parserOptions ParserOptions, processingOptions p
 	}
 
 	var ec *errata.Collection
-	ec, err = errata.LoadErrata(cfg, parserOptions.ErrataPath)
+	ec, err = errata.LoadErrata(cfg, parserOptions.ErrataPath, parserOptions.ErrataOverlayPath)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
## Description

This PR introduces support for an errata overlay system. Users can specify an optional `--errata-overlay` flag pointing to an overlay YAML configuration. The settings inside the overlay are merged on top of the main errata definitions, with overlay definitions taking priority.

### Changes

- Added the ErrataOverlayPath flag to ParserOptions in matter/spec/option.go.
- Configured LoadErrata in errata/load.go to optionally accept and process the overlay file.
- Introduced Merge methods for Errata and its children in errata/merge.go to handle deep merging of SDK types, attributes, command structures, and lists of custom fields.
- Added comprehensive unit tests in errata/load_test.go verifying correct prioritization and deep merging of nested settings inside the sdk: section.
