### PR TITLE
Implement ZAP Matter IDL Generation Tooling

### DIFF
--- a/cmd/action/zapdiff.go
+++ b/cmd/action/zapdiff.go
@@ -32,7 +32,7 @@ type ZAPDiff struct {
 
 func (z *ZAPDiff) Run(cc *cli.Context) (err error) {
 	slog.Info("Running ZAP generation", "attributes", z.GenAttributes)
-	zapCmd := &cli.ZAP{}
+	zapCmd := &cli.ZAPXML{}
 	zapCmd.Root = z.SpecRoot
 	zapCmd.SdkRoot = z.GeneratedSDKRoot
 	zapCmd.Attribute = []string{z.GenAttributes}

--- a/cmd/cli/zap.go
+++ b/cmd/cli/zap.go
@@ -1,15 +1,30 @@
 package cli
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"slices"
+	"strings"
+
 	"github.com/project-chip/alchemy/cmd/common"
 	"github.com/project-chip/alchemy/internal/files"
 	"github.com/project-chip/alchemy/internal/pipeline"
 	"github.com/project-chip/alchemy/matter/spec"
 	"github.com/project-chip/alchemy/sdk"
+	"github.com/project-chip/alchemy/zap"
+	"github.com/project-chip/alchemy/zap/regen"
 	"github.com/project-chip/alchemy/zap/render"
 )
 
 type ZAP struct {
+	ZAPXML             ZAPXML                `cmd:"" name:"xml" default:"withargs"`
+	ZAPRegen           ZAPRegen              `cmd:"" name:"regen"`
+	ControllerClusters ZAPControllerClusters `cmd:"" name:"controller-clusters"`
+}
+
+type ZAPXML struct {
 	common.ASCIIDocAttributes  `embed:""`
 	pipeline.ProcessingOptions `embed:""`
 	files.OutputOptions        `embed:""`
@@ -19,7 +34,7 @@ type ZAP struct {
 	render.TemplateOptions     `embed:""`
 }
 
-func (z *ZAP) Run(cc *Context) (err error) {
+func (z *ZAPXML) Run(cc *Context) (err error) {
 
 	err = sdk.CheckAlchemyVersion(z.SdkRoot)
 	if err != nil {
@@ -204,3 +219,165 @@ func (z *ZAP) Run(cc *Context) (err error) {
 
 	return
 }
+
+type ZAPRegen struct {
+	common.ASCIIDocAttributes  `embed:""`
+	pipeline.ProcessingOptions `embed:""`
+	files.OutputOptions        `embed:""`
+	spec.ParserOptions         `embed:""`
+	spec.FilterOptions         `embed:""`
+	sdk.SDKOptions             `embed:""`
+	render.TemplateOptions     `embed:""`
+}
+
+func (z *ZAPRegen) Run(cc *Context) (err error) {
+
+	var specification *spec.Specification
+	specification, _, err = spec.Parse(cc, z.ParserOptions, z.ProcessingOptions, []spec.BuilderOption{spec.PatchForSdk(true)}, z.ASCIIDocAttributes.ToList())
+	if err != nil {
+		return
+	}
+
+	err = sdk.ApplyErrata(specification)
+	if err != nil {
+		return
+	}
+
+	zapTargeter := regen.Targeter(z.SdkRoot)
+
+	var zapPaths pipeline.Paths
+	zapPaths, err = pipeline.Start(cc, zapTargeter)
+	if err != nil {
+		return
+	}
+
+	var reader regen.Reader
+	reader, err = regen.NewReader()
+	if err != nil {
+		return
+	}
+
+	var zapFiles pipeline.Map[string, *pipeline.Data[*zap.File]]
+	zapFiles, err = pipeline.Parallel(cc, z.ProcessingOptions, reader, zapPaths)
+	if err != nil {
+		return
+	}
+
+	var renderer regen.IdlRenderer
+	renderer, err = regen.NewIdlRenderer(specification)
+	if err != nil {
+		return
+	}
+
+	var matterFiles pipeline.StringSet
+	matterFiles, err = pipeline.Parallel(cc, z.ProcessingOptions, renderer, zapFiles)
+	if err != nil {
+		return
+	}
+
+	writer := files.NewWriter[string]("Writing .matter files", z.OutputOptions)
+	err = writer.Write(cc, matterFiles, z.ProcessingOptions)
+
+	return
+}
+
+type ZAPControllerClusters struct {
+	common.ASCIIDocAttributes  `embed:""`
+	pipeline.ProcessingOptions `embed:""`
+	files.OutputOptions        `embed:""`
+	spec.ParserOptions         `embed:""`
+	Output                     string `name:"output" placeholder:"path" help:"Output file or directory for controller-clusters.matter" optional:"" default:"controller-clusters.matter"`
+}
+
+func (z *ZAPControllerClusters) Run(cc *Context) (err error) {
+	var specification *spec.Specification
+	specification, _, err = spec.Parse(cc, z.ParserOptions, z.ProcessingOptions, []spec.BuilderOption{spec.PatchForSdk(true)}, z.ASCIIDocAttributes.ToList())
+	if err != nil {
+		return
+	}
+
+	err = sdk.ApplyErrata(specification)
+	if err != nil {
+		return
+	}
+
+	var clusterRefs []zap.ClusterRef
+	for code, cluster := range specification.ClustersByID {
+		clusterRefs = append(clusterRefs, zap.ClusterRef{
+			Code: int(code),
+			Name: cluster.Name,
+			Side: "server",
+		})
+	}
+
+	slices.SortFunc(clusterRefs, func(a, b zap.ClusterRef) int {
+		return a.Code - b.Code
+	})
+
+	var validDeviceTypeCode uint64
+	for id := range specification.DeviceTypesByID {
+		validDeviceTypeCode = id
+		break
+	}
+
+	syntheticFile := &zap.File{
+		EndpointTypes: []zap.EndpointType{
+			{
+				ID:             0,
+				Name:           "Synthetic Endpoint",
+				DeviceTypeCode: int(validDeviceTypeCode),
+				Clusters:       clusterRefs,
+			},
+		},
+		Endpoints: []zap.Endpoint{
+			{
+				EndpointId:        0,
+				EndpointTypeIndex: 0,
+			},
+		},
+	}
+
+	renderer, err := regen.NewIdlRenderer(specification)
+	if err != nil {
+		return err
+	}
+	renderer.SuppressEndpoints = true
+
+	var zapPath string
+	outPath := filepath.Clean(z.Output)
+	isDir := false
+	if fi, err := os.Stat(outPath); err == nil {
+		isDir = fi.IsDir()
+	} else if strings.HasSuffix(z.Output, "/") || strings.HasSuffix(z.Output, string(filepath.Separator)) {
+		isDir = true
+	}
+
+	if isDir {
+		zapPath = filepath.Join(outPath, "controller-clusters.zap")
+	} else {
+		ext := filepath.Ext(outPath)
+		if ext == "" {
+			zapPath = outPath + ".zap"
+		} else {
+			zapPath = strings.TrimSuffix(outPath, ext) + ".zap"
+		}
+	}
+	zapData := pipeline.NewData[*zap.File](zapPath, syntheticFile)
+
+	outputs, _, err := renderer.Process(cc, zapData, 0, 1)
+	if err != nil {
+		return err
+	}
+
+	if len(outputs) == 0 {
+		return fmt.Errorf("no output generated")
+	}
+
+	writer := files.NewWriter[string]("Writing controller-clusters.matter", z.OutputOptions)
+
+	outputSet := pipeline.StringSet(pipeline.NewMap[string, *pipeline.Data[string]]())
+	outputSet.Store(outputs[0].Path, outputs[0])
+
+	return writer.Write(cc, outputSet, z.ProcessingOptions)
+}
+

--- a/internal/handlebars/common.go
+++ b/internal/handlebars/common.go
@@ -11,5 +11,7 @@ func RegisterCommonHelpers(t *raymond.Template) {
 	t.RegisterHelper("brace", BraceHelper)
 	t.RegisterHelper("format", FormatHelper)
 	t.RegisterHelper("year", YearHelper)
+	t.RegisterHelper("toLower", ToLowerHelper)
+	t.RegisterHelper("toUpper", ToUpperHelper)
 	t.RegisterHelper("indentLength", IndentLengthHelper)
 }

--- a/internal/handlebars/text.go
+++ b/internal/handlebars/text.go
@@ -1,0 +1,15 @@
+package handlebars
+
+import (
+	"strings"
+
+	"github.com/mailgun/raymond/v2"
+)
+
+func ToUpperHelper(s string) raymond.SafeString {
+	return raymond.SafeString(strings.ToUpper(s))
+}
+
+func ToLowerHelper(s string) raymond.SafeString {
+	return raymond.SafeString(strings.ToLower(s))
+}

--- a/internal/text/alphanumeric.go
+++ b/internal/text/alphanumeric.go
@@ -16,6 +16,16 @@ func IsAlphanumeric(s string) bool {
 	return true
 }
 
+func IsUpperCase(s string) bool {
+	for _, r := range s {
+		if unicode.IsUpper(r) {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
 func ParseRelativeNumber(s string) (number int, relative bool, err error) {
 	if len(s) > 0 {
 		switch s[0] {

--- a/matter/namespace.go
+++ b/matter/namespace.go
@@ -33,6 +33,17 @@ func (ns *Namespace) Equals(e types.Entity) bool {
 	return ns.Name == ons.Name
 }
 
+func (ns *Namespace) Clone() *Namespace {
+	nc := &Namespace{entity: entity{source: ns.source, parent: ns.parent}, ID: ns.ID.Clone(), Name: ns.Name}
+	nc.SemanticTags = make([]*SemanticTag, 0, len(ns.SemanticTags))
+	for _, t := range ns.SemanticTags {
+		tc := t.Clone()
+		tc.parent = nc
+		nc.SemanticTags = append(nc.SemanticTags, tc)
+	}
+	return nc
+}
+
 type SemanticTag struct {
 	entity
 
@@ -71,4 +82,9 @@ func NewSemanticTag(namespace *Namespace, source asciidoc.Element) *SemanticTag 
 	return &SemanticTag{
 		entity: entity{parent: namespace, source: source},
 	}
+}
+
+func (ns *SemanticTag) Clone() *SemanticTag {
+	nc := &SemanticTag{entity: entity{source: ns.source, parent: ns.parent}, ID: ns.ID.Clone(), Name: ns.Name, Description: ns.Description}
+	return nc
 }

--- a/matter/namespace.go
+++ b/matter/namespace.go
@@ -34,7 +34,10 @@ func (ns *Namespace) Equals(e types.Entity) bool {
 }
 
 func (ns *Namespace) Clone() *Namespace {
-	nc := &Namespace{entity: entity{source: ns.source, parent: ns.parent}, ID: ns.ID.Clone(), Name: ns.Name}
+	nc := &Namespace{entity: entity{source: ns.source, parent: ns.parent}, Name: ns.Name}
+	if ns.ID != nil {
+		nc.ID = ns.ID.Clone()
+	}
 	nc.SemanticTags = make([]*SemanticTag, 0, len(ns.SemanticTags))
 	for _, t := range ns.SemanticTags {
 		tc := t.Clone()
@@ -85,6 +88,9 @@ func NewSemanticTag(namespace *Namespace, source asciidoc.Element) *SemanticTag 
 }
 
 func (ns *SemanticTag) Clone() *SemanticTag {
-	nc := &SemanticTag{entity: entity{source: ns.source, parent: ns.parent}, ID: ns.ID.Clone(), Name: ns.Name, Description: ns.Description}
+	nc := &SemanticTag{entity: entity{source: ns.source, parent: ns.parent}, Name: ns.Name, Description: ns.Description}
+	if ns.ID != nil {
+		nc.ID = ns.ID.Clone()
+	}
 	return nc
 }

--- a/matter/spec/build.go
+++ b/matter/spec/build.go
@@ -269,10 +269,11 @@ func (sp *Builder) readEntities(spec *Specification, libraries []*Library) (basi
 }
 
 func (spec *Specification) BuildClusterReferences() {
-	iterateOverDataTypes(spec, func(cluster *matter.Cluster, parent, entity types.Entity) {
-		if cluster != nil {
-			spec.ClusterRefs.Add(cluster, entity)
+	TraverseEntities(spec, func(parentCluster *matter.Cluster, parent, entity types.Entity) parse.SearchShould {
+		if parentCluster != nil {
+			spec.ClusterRefs.Add(parentCluster, entity)
 		}
+		return parse.SearchShouldContinue
 	})
 }
 

--- a/matter/spec/iterate.go
+++ b/matter/spec/iterate.go
@@ -1,0 +1,133 @@
+package spec
+
+import (
+	"iter"
+
+	"github.com/project-chip/alchemy/asciidoc/parse"
+	"github.com/project-chip/alchemy/matter"
+	"github.com/project-chip/alchemy/matter/types"
+)
+
+type EntityCallback func(parent types.Entity, entity types.Entity) parse.SearchShould
+
+func traverseYieldEntity(parent types.Entity, entity types.Entity, callback EntityCallback) bool {
+	switch callback(parent, entity) {
+	case parse.SearchShouldStop:
+		return false
+	}
+	return true
+}
+
+func traverseEntityList(parent types.Entity, root types.Entity, children iter.Seq[types.Entity], callback EntityCallback) bool {
+	if parent != nil {
+		switch callback(parent, root) {
+		case parse.SearchShouldStop:
+			return false
+		case parse.SearchShouldSkip:
+			return true
+		case parse.SearchShouldContinue:
+		}
+	}
+	for child := range children {
+		switch callback(root, child) {
+		case parse.SearchShouldStop:
+			return false
+		case parse.SearchShouldSkip:
+			continue
+		case parse.SearchShouldContinue:
+		}
+		switch child := child.(type) {
+		case *matter.Field:
+			var entityFields matter.FieldSet
+			var fieldEntity types.Entity
+			if child.Type == nil {
+				continue
+			}
+			if child.Type.IsArray() {
+				if child.Type.EntryType == nil {
+					continue
+				}
+				if child.Type.EntryType.Entity == nil {
+					continue
+				}
+				fieldEntity = child.Type.EntryType.Entity
+			} else {
+				fieldEntity = child.Type.Entity
+			}
+			if fieldEntity == nil {
+				continue
+			}
+			switch entity := fieldEntity.(type) {
+			case *matter.Struct:
+				entityFields = entity.Fields
+			case *matter.Command:
+				entityFields = entity.Fields
+			case *matter.Event:
+				entityFields = entity.Fields
+			}
+			if !traverseEntityList(child, fieldEntity, entityFields.Iterate(), callback) {
+				return false
+			}
+		case *matter.Bitmap:
+			if !traverseEntityList(nil, child, child.Bits.Iterate(), callback) {
+				return false
+			}
+		case *matter.Enum:
+			if !traverseEntityList(nil, child, child.Values.Iterate(), callback) {
+				return false
+			}
+		case *matter.Struct:
+			if !traverseEntityList(nil, child, child.Fields.Iterate(), callback) {
+				return false
+			}
+		case *matter.Command:
+			if !traverseEntityList(nil, child, child.Fields.Iterate(), callback) {
+				return false
+			}
+		}
+
+	}
+	return true
+}
+
+func traverseClusterEntities(c *matter.Cluster, callback EntityCallback) parse.SearchShould {
+	if c.Features != nil {
+		if !traverseEntityList(c, c.Features, c.Features.Iterate(), callback) {
+			return parse.SearchShouldStop
+		}
+	}
+	for _, bm := range c.Bitmaps {
+		if !traverseEntityList(c, bm, bm.Bits.Iterate(), callback) {
+			return parse.SearchShouldStop
+		}
+	}
+	for _, en := range c.Enums {
+		if !traverseEntityList(c, en, en.Values.Iterate(), callback) {
+			return parse.SearchShouldStop
+		}
+	}
+	for _, s := range c.Structs {
+		if !traverseEntityList(c, s, s.Fields.Iterate(), callback) {
+			return parse.SearchShouldStop
+		}
+	}
+	for _, cmd := range c.Commands {
+		if !traverseEntityList(c, cmd, cmd.Fields.Iterate(), callback) {
+			return parse.SearchShouldStop
+		}
+		if cmd.Response != nil && cmd.Response.Entity != nil && cmd.Response.Name == "" {
+			if !traverseYieldEntity(cmd, cmd.Response.Entity, callback) {
+				return parse.SearchShouldStop
+			}
+		}
+	}
+	for _, ev := range c.Events {
+		if !traverseEntityList(c, ev, ev.Fields.Iterate(), callback) {
+			return parse.SearchShouldStop
+		}
+	}
+	if !traverseEntityList(nil, c, c.Attributes.Iterate(), callback) {
+		return parse.SearchShouldStop
+	}
+	return parse.SearchShouldContinue
+}

--- a/matter/spec/refs.go
+++ b/matter/spec/refs.go
@@ -3,6 +3,7 @@ package spec
 import (
 	"sync"
 
+	"github.com/project-chip/alchemy/asciidoc/parse"
 	"github.com/project-chip/alchemy/internal/pipeline"
 	"github.com/project-chip/alchemy/matter"
 	"github.com/project-chip/alchemy/matter/types"
@@ -47,40 +48,21 @@ func (cr *EntityRefs[T]) Get(m types.Entity) (pipeline.Map[T, struct{}], bool) {
 }
 
 func (spec *Specification) BuildDataTypeReferences() {
-	iterateOverDataTypes(spec, func(cluster *matter.Cluster, parent, entity types.Entity) {
-		spec.DataTypeRefs.Add(parent, entity)
+	TraverseEntities(spec, func(parentCluster *matter.Cluster, parent, entity types.Entity) parse.SearchShould {
+		if parent != nil {
+			spec.DataTypeRefs.Add(parent, entity)
+		}
+		return parse.SearchShouldContinue
 	})
 }
 
-func iterateOverDataTypes(spec *Specification, callback func(cluster *matter.Cluster, parent, entity types.Entity)) {
+func TraverseEntities(spec *Specification, callback func(parentCluster *matter.Cluster, parent, entity types.Entity) parse.SearchShould) {
 	for _, c := range spec.ClustersByName {
-		for p, e := range c.IterateDataTypes() {
-			callback(c, p, e)
-		}
+		traverseClusterEntities(c, func(parent, entity types.Entity) parse.SearchShould {
+			return callback(c, parent, entity)
+		})
 	}
-	for e := range spec.GlobalObjects {
-		switch en := e.(type) {
-		case *matter.Struct:
-			for _, f := range en.Fields {
-				for p, e := range f.IterateDataTypes() {
-					callback(nil, p, e)
-				}
-			}
-		case *matter.Command:
-			for _, f := range en.Fields {
-				for p, e := range f.IterateDataTypes() {
-					callback(nil, p, e)
-				}
-			}
-			if en.Response != nil && en.Response.Entity != nil && en.Response.Name == "" {
-				callback(nil, en, en.Response.Entity)
-			}
-		case *matter.Event:
-			for _, f := range en.Fields {
-				for p, e := range f.IterateDataTypes() {
-					callback(nil, p, e)
-				}
-			}
-		}
-	}
+	traverseEntityList(nil, nil, spec.GlobalObjects.Iterate(), func(parent, entity types.Entity) parse.SearchShould {
+		return callback(nil, parent, entity)
+	})
 }

--- a/matter/types/base.go
+++ b/matter/types/base.go
@@ -137,6 +137,16 @@ func (bdt BaseDataType) IsSimple() bool {
 	return false
 }
 
+func (bdt BaseDataType) HasLength() bool {
+	switch bdt {
+	case BaseDataTypeString,
+		BaseDataTypeOctStr,
+		BaseDataTypeMessageID:
+		return true
+	}
+	return false
+}
+
 func BaseDataTypeName(baseDataType BaseDataType) string {
 	switch baseDataType {
 	case BaseDataTypeUnknown:

--- a/matter/types/data.go
+++ b/matter/types/data.go
@@ -263,7 +263,7 @@ func (dt *DataType) Clone() *DataType {
 }
 
 func (dt *DataType) HasLength() bool {
-	return dt != nil && (dt.BaseType == BaseDataTypeString || dt.BaseType == BaseDataTypeOctStr || dt.BaseType == BaseDataTypeMessageID)
+	return dt != nil && (dt.BaseType.HasLength())
 }
 
 func (dt *DataType) IsArray() bool {

--- a/matter/types/entity.go
+++ b/matter/types/entity.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"encoding/json"
+	"iter"
 
 	"github.com/project-chip/alchemy/asciidoc"
 )
@@ -104,6 +105,16 @@ func Filter[T Entity](list []Entity) (out []T) {
 }
 
 type EntitySet[S any] map[Entity]S
+
+func (es EntitySet[S]) Iterate() iter.Seq[Entity] {
+	return func(yield func(Entity) bool) {
+		for e := range es {
+			if !yield(e) {
+				return
+			}
+		}
+	}
+}
 
 func FilterSet[T Entity, S any](set EntitySet[S]) (out []T) {
 	for e := range set {

--- a/matter/types/size.go
+++ b/matter/types/size.go
@@ -51,6 +51,8 @@ func (dt *DataType) Size() int {
 		return 4
 	case BaseDataTypeIPv6Address, BaseDataTypeMessageID:
 		return 16
+	case BaseDataTypeIPv6Prefix:
+		return 254
 	case BaseDataTypeSemanticTag:
 		return 4
 	case BaseDataTypeNamespaceID:

--- a/sdk/types.go
+++ b/sdk/types.go
@@ -50,6 +50,20 @@ func ToUnderlyingType(dt types.BaseDataType) types.BaseDataType {
 		return types.BaseDataTypeUInt8
 	case types.BaseDataTypePercentHundredths:
 		return types.BaseDataTypeUInt16
+	case types.BaseDataTypeFabricIndex, types.BaseDataTypePriority, types.BaseDataTypeStatus, types.BaseDataTypeActionID:
+		return types.BaseDataTypeUInt8
+	case types.BaseDataTypeGroupID, types.BaseDataTypeEndpointNumber, types.BaseDataTypeVendorID, types.BaseDataTypeEntryIndex:
+		return types.BaseDataTypeUInt16
+	case types.BaseDataTypeDeviceTypeID,
+		types.BaseDataTypeClusterID, types.BaseDataTypeAttributeID, types.BaseDataTypeFieldID, types.BaseDataTypeEventID, types.BaseDataTypeCommandID,
+		types.BaseDataTypeTransactionID, types.BaseDataTypeDataVersion:
+		return types.BaseDataTypeUInt32
+	case types.BaseDataTypeFabricID, types.BaseDataTypeNodeID, types.BaseDataTypeSubjectID, types.BaseDataTypeEventNumber:
+		return types.BaseDataTypeUInt64
+	case types.BaseDataTypeNamespaceID, types.BaseDataTypeTag:
+		return types.BaseDataTypeUInt8
+	case types.BaseDataTypeIPAddress, types.BaseDataTypeIPv4Address, types.BaseDataTypeIPv6Address, types.BaseDataTypeIPv6Prefix, types.BaseDataTypeHardwareAddress:
+		return types.BaseDataTypeOctStr
 	default:
 		return dt
 	}

--- a/zap/datatype.go
+++ b/zap/datatype.go
@@ -474,6 +474,12 @@ func FieldToZapDataType(fs matter.FieldSet, f *matter.Field, constraint constrai
 		// Special case; needs to be long_octet_string if over 255
 		return "long_octet_string"
 	}
+	if f.Type.BaseType == types.BaseDataTypeTag {
+		switch f.Type.Entity.(type) {
+		case *matter.Namespace:
+			return f.Name + "Tag"
+		}
+	}
 	if f.Type.IsArray() {
 		return DataTypeName(f.Type.EntryType)
 	}

--- a/zap/json.go
+++ b/zap/json.go
@@ -1,0 +1,130 @@
+package zap
+
+import (
+	"encoding/json"
+
+	"github.com/project-chip/alchemy/matter"
+)
+
+type File struct {
+	FileFormat    int            `json:"fileFormat"`
+	FeatureLevel  int            `json:"featureLevel"`
+	Creator       string         `json:"creator"`
+	KeyValuePairs []KeyValuePair `json:"keyValuePairs"`
+	Package       []Package      `json:"package"`
+	EndpointTypes []EndpointType `json:"endpointTypes"`
+	Endpoints     []Endpoint     `json:"endpoints"`
+}
+
+type KeyValuePair struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+type Package struct {
+	PathRelativity string       `json:"pathRelativity"`
+	Path           string       `json:"path"`
+	Type           string       `json:"type"`
+	Category       string       `json:"category"`
+	Version        NumberString `json:"version"`
+	Description    string       `json:"description"`
+}
+
+type EndpointType struct {
+	ID                int             `json:"id"`
+	Name              string          `json:"name"`
+	DeviceTypeRef     DeviceTypeRef   `json:"deviceTypeRef"`
+	DeviceTypes       []DeviceTypeRef `json:"deviceTypes"`
+	DeviceVersions    []int           `json:"deviceVersions"`
+	DeviceIdentifiers []int           `json:"deviceIdentifiers"`
+
+	DeviceTypeCode      int    `json:"deviceTypeCode"`
+	DeviceTypeProfileId int    `json:"deviceTypeProfileId"`
+	DeviceTypeName      string `json:"deviceTypeName"`
+
+	Clusters []ClusterRef `json:"clusters"`
+
+	DeviceType *matter.DeviceType `json:"-"`
+}
+
+type DeviceTypeRef struct {
+	Code            int    `json:"code"`
+	ProfileId       int    `json:"profileId"`
+	Label           string `json:"label"`
+	Name            string `json:"name"`
+	DeviceTypeOrder int    `json:"deviceTypeOrder"`
+}
+
+type ClusterRef struct {
+	Name        string `json:"name"`
+	Code        int    `json:"code"`
+	MfgCode     *int   `json:"mfgCode"`
+	Define      string `json:"define"`
+	Side        string `json:"side"`
+	ApiMaturity string `json:"apiMaturity"`
+	Enabled     int    `json:"enabled"`
+
+	Cluster *matter.Cluster `json:"-"`
+
+	Attributes []AttributeRef `json:"attributes"`
+	Commands   []CommandRef   `json:"commands"`
+	Events     []EventRef     `json:"events"`
+}
+
+type CommandRef struct {
+	Name       string `json:"name"`
+	Code       int    `json:"code"`
+	MfgCode    *int   `json:"mfgCode"`
+	Source     string `json:"source"`
+	IsIncoming int    `json:"isIncoming"`
+	IsEnabled  int    `json:"isEnabled"`
+
+	Command *matter.Command `json:"-"`
+}
+
+type AttributeRef struct {
+	Name             string `json:"name"`
+	Code             int    `json:"code"`
+	MfgCode          *int   `json:"mfgCode"`
+	Side             string `json:"side"`
+	Type             string `json:"type"`
+	Included         int    `json:"included"`
+	StorageOption    string `json:"storageOption"`
+	Singleton        int    `json:"singleton"`
+	Bounded          int    `json:"bounded"`
+	DefaultValue     string `json:"defaultValue"`
+	Reportable       int    `json:"reportable"`
+	MinInterval      int    `json:"minInterval"`
+	MaxInterval      int    `json:"maxInterval"`
+	ReportableChange int    `json:"reportableChange"`
+}
+
+type EventRef struct {
+	Name     string `json:"name"`
+	Code     int    `json:"code"`
+	MfgCode  *int   `json:"mfgCode"`
+	Side     string `json:"side"`
+	Included int    `json:"included"`
+}
+
+type Endpoint struct {
+	EndpointTypeName         string `json:"endpointTypeName"`
+	EndpointTypeIndex        int    `json:"endpointTypeIndex"`
+	ParentEndpointIdentifier *int   `json:"parentEndpointIdentifier"`
+	ProfileId                int    `json:"profileId"`
+	EndpointId               int    `json:"endpointId"`
+	NetworkId                int    `json:"networkId"`
+}
+
+type NumberString struct {
+	Number *int
+	String *string
+}
+
+func (f *NumberString) UnmarshalJSON(b []byte) error {
+	if len(b) > 0 && b[0] == '"' {
+		return json.Unmarshal(b, &f.String)
+
+	}
+	return json.Unmarshal(b, &f.Number)
+}

--- a/zap/regen/bitmap.go
+++ b/zap/regen/bitmap.go
@@ -1,0 +1,101 @@
+package regen
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/mailgun/raymond/v2"
+	"github.com/project-chip/alchemy/matter"
+	"github.com/project-chip/alchemy/matter/conformance"
+	"github.com/project-chip/alchemy/matter/spec"
+	"github.com/project-chip/alchemy/matter/types"
+	"github.com/project-chip/alchemy/zap"
+)
+
+func clusterBitmapsHelper(spec *spec.Specification) func(clusterInfo ClusterInfo, options *raymond.Options) raymond.SafeString {
+	return func(clusterInfo ClusterInfo, options *raymond.Options) raymond.SafeString {
+		bitmaps := make(matter.BitmapSet, 0, len(clusterInfo.ReferencedBitmaps))
+		for _, bm := range clusterInfo.ReferencedBitmaps {
+			if len(filterBits(bm)) > 0 {
+				bitmaps = append(bitmaps, bm)
+			}
+		}
+		cluster := clusterInfo.Cluster
+		if cluster.Features != nil {
+			if len(filterBits(&cluster.Features.Bitmap)) > 0 {
+				features := cluster.Features.Bitmap.Clone()
+
+				// ZAP renames this for some reason
+				features.Name = "Feature"
+				bitmaps = append(bitmaps, features)
+			}
+		}
+		slices.SortStableFunc(bitmaps, func(a *matter.Bitmap, b *matter.Bitmap) int {
+			return strings.Compare(a.Name, b.Name)
+		})
+
+		return enumerateEntitiesHelper(bitmaps, spec, options)
+	}
+}
+
+func bitmapTypeHelper(bitmap matter.Bitmap) raymond.SafeString {
+	switch bitmap.Type.BaseType {
+	case types.BaseDataTypeMap8:
+		return raymond.SafeString("bitmap8")
+	case types.BaseDataTypeMap16:
+		return raymond.SafeString("bitmap16")
+	case types.BaseDataTypeMap32:
+		return raymond.SafeString("bitmap32")
+	case types.BaseDataTypeMap64:
+		return raymond.SafeString("bitmap24")
+	default:
+		return raymond.SafeString("unknown bitmap type")
+	}
+}
+
+func bitNameHelper(bit any) raymond.SafeString {
+	switch bit := bit.(type) {
+	case matter.BitmapBit:
+		return asUpperCamelCaseHelper(bit.Name())
+	case matter.Feature:
+		return asUpperCamelCaseHelper(bit.Name())
+	default:
+		return raymond.SafeString(fmt.Sprintf("unexpected bitName type: %T", bit))
+	}
+}
+
+func bitMaskHelper(bit any) raymond.SafeString {
+	switch bit := bit.(type) {
+	case matter.BitmapBit:
+		mask, err := bit.Mask()
+		if err != nil {
+			return raymond.SafeString(fmt.Sprintf("error converting bitmap mask: %v", err))
+		}
+		return raymond.SafeString(fmt.Sprintf("0x%X", mask))
+	case matter.Feature:
+		mask, err := bit.Mask()
+		if err != nil {
+			return raymond.SafeString(fmt.Sprintf("error converting feature mask: %v", err))
+		}
+		return raymond.SafeString(fmt.Sprintf("0x%X", mask))
+	default:
+		return raymond.SafeString(fmt.Sprintf("unexpected bitName type: %T", bit))
+	}
+}
+
+func filterBits(bm *matter.Bitmap) (bits matter.BitSet) {
+	for _, b := range bm.Bits {
+		if conformance.IsZigbee(b.Conformance()) || zap.IsDisallowed(b, b.Conformance()) || conformance.IsDeprecated(b.Conformance()) {
+			continue
+		}
+		bits = append(bits, b)
+	}
+	return
+}
+
+func bitmapBitsHelper(spec *spec.Specification) func(bm matter.Bitmap, options *raymond.Options) raymond.SafeString {
+	return func(bm matter.Bitmap, options *raymond.Options) raymond.SafeString {
+		return enumerateEntitiesHelper(filterBits(&bm), spec, options)
+	}
+}

--- a/zap/regen/bitmap.go
+++ b/zap/regen/bitmap.go
@@ -13,22 +13,51 @@ import (
 	"github.com/project-chip/alchemy/zap"
 )
 
-func clusterBitmapsHelper(spec *spec.Specification) func(clusterInfo ClusterInfo, options *raymond.Options) raymond.SafeString {
-	return func(clusterInfo ClusterInfo, options *raymond.Options) raymond.SafeString {
-		bitmaps := make(matter.BitmapSet, 0, len(clusterInfo.ReferencedBitmaps))
-		for _, bm := range clusterInfo.ReferencedBitmaps {
-			if len(filterBits(bm)) > 0 {
-				bitmaps = append(bitmaps, bm)
+func clusterBitmapsHelper(spec *spec.Specification) func(val any, options *raymond.Options) raymond.SafeString {
+	return func(val any, options *raymond.Options) raymond.SafeString {
+		var bitmaps matter.BitmapSet
+		switch val := val.(type) {
+		case ClusterInfo:
+			for _, bm := range val.ReferencedBitmaps {
+				if len(filterBits(bm)) > 0 {
+					bitmaps = append(bitmaps, bm)
+				}
 			}
-		}
-		cluster := clusterInfo.Cluster
-		if cluster.Features != nil {
-			if len(filterBits(&cluster.Features.Bitmap)) > 0 {
-				features := cluster.Features.Bitmap.Clone()
-
-				// ZAP renames this for some reason
-				features.Name = "Feature"
-				bitmaps = append(bitmaps, features)
+			cluster := val.Cluster
+			if cluster != nil && cluster.Features != nil {
+				if len(filterBits(&cluster.Features.Bitmap)) > 0 {
+					features := cluster.Features.Bitmap.Clone()
+					features.Name = "Feature"
+					bitmaps = append(bitmaps, features)
+				}
+			}
+		case *ClusterInfo:
+			if val != nil {
+				for _, bm := range val.ReferencedBitmaps {
+					if len(filterBits(bm)) > 0 {
+						bitmaps = append(bitmaps, bm)
+					}
+				}
+				cluster := val.Cluster
+				if cluster != nil && cluster.Features != nil {
+					if len(filterBits(&cluster.Features.Bitmap)) > 0 {
+						features := cluster.Features.Bitmap.Clone()
+						features.Name = "Feature"
+						bitmaps = append(bitmaps, features)
+					}
+				}
+			}
+		case matter.BitmapSet:
+			for _, bm := range val {
+				if len(filterBits(bm)) > 0 {
+					bitmaps = append(bitmaps, bm)
+				}
+			}
+		case []*matter.Bitmap:
+			for _, bm := range val {
+				if len(filterBits(bm)) > 0 {
+					bitmaps = append(bitmaps, bm)
+				}
 			}
 		}
 		slices.SortStableFunc(bitmaps, func(a *matter.Bitmap, b *matter.Bitmap) int {

--- a/zap/regen/case.go
+++ b/zap/regen/case.go
@@ -1,0 +1,109 @@
+package regen
+
+import (
+	"regexp"
+	"strings"
+	"unicode"
+
+	"github.com/mailgun/raymond/v2"
+)
+
+func asUpperCamelCaseHelper(value string) raymond.SafeString {
+	return raymond.SafeString(caseify(value, false, true))
+}
+
+func asUpperCamelCaseIgnoreAcronymsHelper(value string) raymond.SafeString {
+	return raymond.SafeString(caseify(value, false, false))
+}
+
+func asLowerCamelCaseHelper(value string) raymond.SafeString {
+	if len(value) > 1 && isUpperCase(value) {
+		return raymond.SafeString(strings.ToLower(value))
+	}
+	return raymond.SafeString(caseify(value, true, true))
+}
+
+func upperCamelCaseDiffersHelper(value string, options *raymond.Options) string {
+	if string(asUpperCamelCaseHelper(value)) != value {
+		return options.Fn()
+	}
+	return options.Inverse()
+}
+
+func lowerCamelCaseDiffersHelper(value string, options *raymond.Options) string {
+	if string(asLowerCamelCaseHelper(value)) != value {
+		return options.Fn()
+	}
+	return options.Inverse()
+}
+
+var (
+	wordPattern         = regexp.MustCompile(`[ _\-/]`)
+	invalidCharsPattern = regexp.MustCompile(`[+()&]`)
+	cleanupPattern      = regexp.MustCompile(`[^A-Za-z0-9_]`)
+)
+
+func isUpperCase(s string) bool {
+	return s == strings.ToUpper(s)
+}
+
+func caseify(s string, camelCase bool, preserveAcronyms bool) string {
+	cleanedLabel := invalidCharsPattern.ReplaceAllString(s, "")
+	tokens := wordPattern.Split(cleanedLabel, -1)
+
+	var result strings.Builder
+	for index, token := range tokens {
+		if token == "PERSONAL" {
+			token = "Personal"
+		}
+		runes := []rune(token)
+
+		if len(runes) == 0 {
+			continue
+		}
+
+		isAllUpperCase := isUpperCase(token)
+
+		if isAllUpperCase && preserveAcronyms {
+			result.WriteString(token)
+			continue
+		}
+
+		firstRune := runes[0]
+		var processedFirstRune rune
+
+		if index == 0 && camelCase {
+			processedFirstRune = unicode.ToLower(firstRune)
+		} else {
+			processedFirstRune = unicode.ToUpper(firstRune)
+		}
+		result.WriteRune(processedFirstRune)
+
+		if len(runes) > 1 {
+			if !isAllUpperCase {
+				result.WriteString(string(runes[1:]))
+			} else {
+				result.WriteString(strings.ToLower(string(runes[1:])))
+			}
+		}
+	}
+
+	str := result.String()
+
+	if camelCase && preserveAcronyms {
+		originalRunes := []rune(s)
+		if !wordPattern.MatchString(s) &&
+			len(originalRunes) > 1 &&
+			string(originalRunes[0:2]) == strings.ToUpper(string(originalRunes[0:2])) &&
+			s != strings.ToUpper(s) {
+
+			strRunes := []rune(str)
+			if len(strRunes) > 0 {
+				strRunes[0] = unicode.ToUpper(strRunes[0])
+				str = string(strRunes)
+			}
+		}
+	}
+
+	return cleanupPattern.ReplaceAllString(str, "")
+}

--- a/zap/regen/cluster.go
+++ b/zap/regen/cluster.go
@@ -1,0 +1,78 @@
+package regen
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/mailgun/raymond/v2"
+	"github.com/project-chip/alchemy/matter"
+	"github.com/project-chip/alchemy/matter/spec"
+)
+
+type ClusterInfo struct {
+	Cluster *matter.Cluster
+
+	ReferencedBitmaps matter.BitmapSet
+	ReferencedEnums   matter.EnumSet
+	ReferencedStructs matter.StructSet
+}
+
+func clustersHelper(spec *spec.Specification) func(clusterInfos []*ClusterInfo, options *raymond.Options) raymond.SafeString {
+	return func(clusterInfos []*ClusterInfo, options *raymond.Options) raymond.SafeString {
+		var result strings.Builder
+		for i, en := range clusterInfos {
+			df := options.DataFrame().Copy()
+			df.Set("index", i)
+			df.Set("key", nil)
+			df.Set("first", i == 0)
+			df.Set("last", i == len(clusterInfos)-1)
+			if spec != nil {
+				df.Set("provisional", isProvisional(spec, en.Cluster))
+			}
+			result.WriteString(options.FnCtxData(*en, df))
+		}
+		return raymond.SafeString(result.String())
+	}
+}
+
+func clusterAttributesHelper(spec *spec.Specification, commonAttributes matter.FieldSet) func(cluster matter.Cluster, options *raymond.Options) raymond.SafeString {
+	return func(cluster matter.Cluster, options *raymond.Options) raymond.SafeString {
+		cas := make(matter.FieldSet, 0, len(commonAttributes))
+		for _, ca := range commonAttributes {
+			ca = ca.Clone()
+			ca.SetParent(&cluster)
+			cas = append(cas, ca)
+		}
+		attributes := filterEntities(cluster.Attributes, cas)
+		slices.SortStableFunc(attributes, func(a *matter.Field, b *matter.Field) int {
+			return a.ID.Compare(b.ID)
+		})
+		return enumerateEntitiesHelper(attributes, spec, options)
+	}
+}
+
+func clusterStructsHelper(spec *spec.Specification) func(s matter.StructSet, options *raymond.Options) raymond.SafeString {
+	return func(s matter.StructSet, options *raymond.Options) raymond.SafeString {
+		structs := filterEntities(s)
+		slices.SortStableFunc(structs, func(a *matter.Struct, b *matter.Struct) int {
+			if a.FabricScoping != b.FabricScoping {
+				if a.FabricScoping == matter.FabricScopingScoped {
+					return 1
+				}
+				if b.FabricScoping == matter.FabricScopingScoped {
+					return -1
+				}
+			}
+			return strings.Compare(a.Name, b.Name)
+		})
+		return enumerateEntitiesHelper(structs, spec, options)
+	}
+}
+
+func clusterEventsHelper(spec *spec.Specification) func(cluster matter.Cluster, options *raymond.Options) raymond.SafeString {
+	return func(cluster matter.Cluster, options *raymond.Options) raymond.SafeString {
+		events := make(matter.EventSet, len(cluster.Events))
+		copy(events, cluster.Events)
+		return enumerateEntitiesHelper(events, spec, options)
+	}
+}

--- a/zap/regen/command.go
+++ b/zap/regen/command.go
@@ -1,0 +1,88 @@
+package regen
+
+import (
+	"slices"
+
+	"github.com/mailgun/raymond/v2"
+	"github.com/project-chip/alchemy/matter"
+	"github.com/project-chip/alchemy/matter/conformance"
+	"github.com/project-chip/alchemy/matter/spec"
+	"github.com/project-chip/alchemy/matter/types"
+	"github.com/project-chip/alchemy/zap"
+)
+
+func commandsHelper(spec *spec.Specification) func(commands matter.CommandSet, options *raymond.Options) raymond.SafeString {
+	return func(commands matter.CommandSet, options *raymond.Options) raymond.SafeString {
+		var sortedCommands matter.CommandSet
+		for _, cmd := range commands {
+			if !entityShouldBeIncluded(cmd) {
+				continue
+			}
+			sortedCommands = append(sortedCommands, cmd)
+		}
+		slices.SortStableFunc(sortedCommands, func(a *matter.Command, b *matter.Command) int {
+			cmp := a.ID.Compare(b.ID)
+			if cmp != 0 {
+				return cmp
+			}
+			if a.Direction == matter.InterfaceServer {
+				return 1
+			} else {
+				return 0
+			}
+		})
+		return enumerateEntitiesHelper(sortedCommands, spec, options)
+	}
+}
+
+func commandFieldsHelper(spec *spec.Specification) func(matter.Command, *raymond.Options) raymond.SafeString {
+	return func(cmd matter.Command, options *raymond.Options) raymond.SafeString {
+		fields := filterEntities(cmd.Fields)
+		if cmd.Access.FabricSensitivity == matter.FabricSensitivitySensitive {
+			fields = append(fields, &matter.Field{ID: matter.NewNumber(254), Name: "FabricIndex", Type: types.NewDataType(types.BaseDataTypeFabricIndex, types.DataTypeRankScalar), Conformance: conformance.Set{&conformance.Mandatory{}}})
+		}
+		return enumerateEntitiesHelper(fields, spec, options)
+	}
+}
+
+func requestsHelper(spec *spec.Specification) func(commands matter.CommandSet, options *raymond.Options) raymond.SafeString {
+	return func(commands matter.CommandSet, options *raymond.Options) raymond.SafeString {
+		var requests []*matter.Command
+		for _, command := range commands {
+			if conformance.IsZigbee(command.Conformance) || zap.IsDisallowed(command, command.Conformance) {
+				continue
+			}
+			switch command.Direction {
+			case matter.InterfaceServer:
+				requests = append(requests, command)
+			}
+		}
+		slices.SortStableFunc(requests, func(a *matter.Command, b *matter.Command) int {
+			return a.ID.Compare(b.ID)
+		})
+		return enumerateEntitiesHelper(requests, spec, options)
+	}
+}
+
+func isTimedHelper(command matter.Command, options *raymond.Options) string {
+	if command.Access.Timing == matter.TimingTimed {
+		return options.Fn()
+	} else {
+		return options.Inverse()
+	}
+}
+
+func requestNameHelper(command matter.Command) raymond.SafeString {
+	return raymond.SafeString(command.Name)
+}
+
+func responseNameHelper(command matter.Command) raymond.SafeString {
+	if command.Response != nil {
+		switch response := command.Response.Entity.(type) {
+		case *matter.Command:
+			return raymond.SafeString(response.Name)
+		default:
+		}
+	}
+	return raymond.SafeString("DefaultSuccess")
+}

--- a/zap/regen/endpoint.go
+++ b/zap/regen/endpoint.go
@@ -1,0 +1,51 @@
+package regen
+
+import (
+	"github.com/mailgun/raymond/v2"
+	"github.com/project-chip/alchemy/matter/spec"
+	"github.com/project-chip/alchemy/zap"
+)
+
+type Endpoint struct {
+	ID int
+	zap.EndpointType
+
+	Servers []*ClusterInfo
+	Clients []*ClusterInfo
+}
+
+func endpointServersHelper(spec *spec.Specification) func(Endpoint, *raymond.Options) raymond.SafeString {
+	return func(endpoint Endpoint, options *raymond.Options) raymond.SafeString {
+		servers := make([]zap.ClusterRef, 0, len(endpoint.Clusters))
+		for _, clusterRef := range endpoint.Clusters {
+			if clusterRef.Side != "server" {
+				continue
+			}
+			cluster, ok := spec.ClustersByID[uint64(clusterRef.Code)]
+			if !ok {
+				continue
+			}
+			clusterRef.Cluster = cluster
+			servers = append(servers, clusterRef)
+		}
+		return enumerateHelper(servers, spec, options)
+	}
+}
+
+func endpointClientsHelper(spec *spec.Specification) func(Endpoint, *raymond.Options) raymond.SafeString {
+	return func(endpoint Endpoint, options *raymond.Options) raymond.SafeString {
+		clients := make([]zap.ClusterRef, 0, len(endpoint.Clusters))
+		for _, clusterRef := range endpoint.Clusters {
+			if clusterRef.Side != "client" {
+				continue
+			}
+			cluster, ok := spec.ClustersByID[uint64(clusterRef.Code)]
+			if !ok {
+				continue
+			}
+			clusterRef.Cluster = cluster
+			clients = append(clients, clusterRef)
+		}
+		return enumerateHelper(clients, spec, options)
+	}
+}

--- a/zap/regen/entities.go
+++ b/zap/regen/entities.go
@@ -1,0 +1,83 @@
+package regen
+
+import (
+	"strings"
+
+	"github.com/mailgun/raymond/v2"
+	"github.com/project-chip/alchemy/matter"
+	"github.com/project-chip/alchemy/matter/conformance"
+	"github.com/project-chip/alchemy/matter/spec"
+	"github.com/project-chip/alchemy/matter/types"
+	"github.com/project-chip/alchemy/provisional"
+	"github.com/project-chip/alchemy/zap"
+)
+
+func entityShouldBeIncluded(e types.Entity) bool {
+	conf := matter.EntityConformance(e)
+	if conformance.IsZigbee(conf) || zap.IsDisallowed(e, conf) || conformance.IsDeprecated(conf) {
+		return false
+	}
+	return true
+}
+
+func filterEntities[T types.Entity](sets ...[]T) (set []T) {
+	for _, s := range sets {
+		for _, e := range s {
+			if !entityShouldBeIncluded(e) {
+				continue
+			}
+			set = append(set, e)
+		}
+	}
+	return
+}
+
+func enumerateEntitiesHelper[T types.Entity](list []T, spec *spec.Specification, options *raymond.Options) raymond.SafeString {
+	var result strings.Builder
+	for i, en := range filterEntities(list) {
+		df := options.DataFrame().Copy()
+		df.Set("index", i)
+		df.Set("key", nil)
+
+		df.Set("first", i == 0)
+		df.Set("last", i == len(list)-1)
+		if spec != nil {
+			refs, ok := spec.ClusterRefs.Get(en)
+			if ok && refs.Size() > 1 {
+				df.Set("shared", true)
+			}
+			df.Set("provisional", isProvisional(spec, en))
+			dr, ok := spec.DataTypeRefs.Get(en)
+			if ok {
+				df.Set("refCount", dr.Size())
+			}
+		}
+		result.WriteString(options.FnCtxData(en, df))
+	}
+	return raymond.SafeString(result.String())
+}
+
+func isProvisional(spec *spec.Specification, entity types.Entity) bool {
+	switch entity := entity.(type) {
+	case *matter.Bitmap:
+		if entity.Name == "Feature" {
+			return false
+		}
+	case *matter.Enum:
+		if strings.HasSuffix(entity.Name, "Tag") {
+			return false
+		}
+	case nil:
+		return false
+	}
+	is := provisional.Check(spec, entity, entity)
+	switch is {
+	case provisional.StateAllClustersProvisional,
+		provisional.StateAllDataTypeReferencesProvisional,
+		provisional.StateExplicitlyProvisional,
+		provisional.StateUnreferenced:
+		return true
+	default:
+		return false
+	}
+}

--- a/zap/regen/enum.go
+++ b/zap/regen/enum.go
@@ -1,0 +1,21 @@
+package regen
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/mailgun/raymond/v2"
+	"github.com/project-chip/alchemy/matter"
+	"github.com/project-chip/alchemy/matter/spec"
+)
+
+func enumsHelper(spec *spec.Specification) func(enums matter.EnumSet, options *raymond.Options) raymond.SafeString {
+	return func(enums matter.EnumSet, options *raymond.Options) raymond.SafeString {
+		sortedEnums := make(matter.EnumSet, len(enums))
+		copy(sortedEnums, enums)
+		slices.SortStableFunc(sortedEnums, func(a *matter.Enum, b *matter.Enum) int {
+			return strings.Compare(a.Name, b.Name)
+		})
+		return enumerateEntitiesHelper(sortedEnums, spec, options)
+	}
+}

--- a/zap/regen/field.go
+++ b/zap/regen/field.go
@@ -1,0 +1,66 @@
+package regen
+
+import (
+	"github.com/mailgun/raymond/v2"
+	"github.com/project-chip/alchemy/matter"
+	"github.com/project-chip/alchemy/matter/conformance"
+	"github.com/project-chip/alchemy/matter/spec"
+	"github.com/project-chip/alchemy/matter/types"
+	"github.com/project-chip/alchemy/zap"
+)
+
+func fieldTypeHelper(field matter.Field, fs matter.FieldSet, options *raymond.Options) raymond.SafeString {
+	return raymond.SafeString(zap.FieldToZapDataType(fs, &field, field.Constraint))
+}
+
+func fieldIsArrayHelper(a any, options *raymond.Options) string {
+	var t *types.DataType
+	switch a := a.(type) {
+	case types.DataType:
+		t = &a
+	case *types.DataType:
+		t = a
+	default:
+		return options.Inverse()
+	}
+	if t == nil {
+		return options.Inverse()
+	}
+	if t.IsArray() {
+		return options.Fn()
+	} else {
+		return options.Inverse()
+	}
+}
+
+func ifHasValidFieldsHelper(fs matter.FieldSet, options *raymond.Options) string {
+	if len(filterEntities(fs)) > 0 {
+		return options.Fn()
+	} else {
+		return options.Inverse()
+	}
+}
+
+func structFieldsHelper(spec *spec.Specification) func(s matter.Struct, options *raymond.Options) raymond.SafeString {
+	return func(s matter.Struct, options *raymond.Options) raymond.SafeString {
+		fields := filterEntities(s.Fields)
+		if s.FabricScoping == matter.FabricScopingScoped {
+			fabricIndex := &matter.Field{ID: matter.NewNumber(254), Name: "FabricIndex", Type: types.NewDataType(types.BaseDataTypeFabricIndex, types.DataTypeRankScalar), Conformance: conformance.Set{&conformance.Mandatory{}}}
+			fabricIndex.SetParent(&s)
+			fields = append(fields, fabricIndex)
+		}
+		return enumerateEntitiesHelper(fields, spec, options)
+	}
+}
+
+func eventFieldsHelper(spec *spec.Specification) func(e matter.Event, options *raymond.Options) raymond.SafeString {
+	return func(e matter.Event, options *raymond.Options) raymond.SafeString {
+		fields := filterEntities(e.Fields)
+		if e.Access.FabricSensitivity == matter.FabricSensitivitySensitive {
+			fabricIndex := &matter.Field{ID: matter.NewNumber(254), Name: "FabricIndex", Type: types.NewDataType(types.BaseDataTypeFabricIndex, types.DataTypeRankScalar), Conformance: conformance.Set{&conformance.Mandatory{}}}
+			fabricIndex.SetParent(&e)
+			fields = append(fields, fabricIndex)
+		}
+		return enumerateEntitiesHelper(fields, spec, options)
+	}
+}

--- a/zap/regen/helper.go
+++ b/zap/regen/helper.go
@@ -1,0 +1,270 @@
+package regen
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/iancoleman/strcase"
+	"github.com/mailgun/raymond/v2"
+	"github.com/project-chip/alchemy/matter"
+	"github.com/project-chip/alchemy/matter/conformance"
+	"github.com/project-chip/alchemy/matter/spec"
+	"github.com/project-chip/alchemy/matter/types"
+	"github.com/project-chip/alchemy/sdk"
+	"github.com/project-chip/alchemy/zap"
+)
+
+func (sp *IdlRenderer) registerIdlHelpers(t *raymond.Template, spec *spec.Specification) {
+	t.RegisterHelper("number", numberHelper)
+	t.RegisterHelper("currentRevision", currentRevisionHelper)
+	t.RegisterHelper("asUpperCamelCase", asUpperCamelCaseHelper)
+	t.RegisterHelper("asUpperCamelCaseIgnoreAcronyms", asUpperCamelCaseIgnoreAcronymsHelper)
+	t.RegisterHelper("asLowerCamelCase", asLowerCamelCaseHelper)
+	t.RegisterHelper("upperCamelCaseDiffers", upperCamelCaseDiffersHelper)
+	t.RegisterHelper("lowerCamelCaseDiffers", lowerCamelCaseDiffersHelper)
+	t.RegisterHelper("descriptionComment", descriptionCommentHelper)
+	t.RegisterHelper("clusters", clustersHelper(spec))
+	t.RegisterHelper("enums", enumsHelper(sp.spec))
+	t.RegisterHelper("structs", clusterStructsHelper(sp.spec))
+	t.RegisterHelper("events", clusterEventsHelper(sp.spec))
+	t.RegisterHelper("commands", commandsHelper(sp.spec))
+	t.RegisterHelper("requests", requestsHelper(sp.spec))
+	t.RegisterHelper("isTimed", isTimedHelper)
+	t.RegisterHelper("requestName", requestNameHelper)
+	t.RegisterHelper("responseName", responseNameHelper)
+	t.RegisterHelper("attributes", clusterAttributesHelper(sp.spec, sp.commonAttributes))
+	t.RegisterHelper("bitmaps", clusterBitmapsHelper(sp.spec))
+	t.RegisterHelper("bitmapBits", bitmapBitsHelper(sp.spec))
+	t.RegisterHelper("structFields", structFieldsHelper(sp.spec))
+	t.RegisterHelper("eventFields", eventFieldsHelper(sp.spec))
+	t.RegisterHelper("commandFields", commandFieldsHelper(sp.spec))
+	t.RegisterHelper("fieldType", fieldTypeHelper)
+	t.RegisterHelper("fieldIsArray", fieldIsArrayHelper)
+	t.RegisterHelper("ifFabricScoped", ifFabricScopedHelper)
+	t.RegisterHelper("ifFabricSensitive", ifFabricSensitiveHelper)
+	t.RegisterHelper("ifOptional", ifOptionalHelper)
+	t.RegisterHelper("ifNullable", ifNullableHelper)
+	t.RegisterHelper("ifReadOnly", ifReadOnlyHelper)
+	t.RegisterHelper("ifHasAccess", ifHasAccessHelper)
+	t.RegisterHelper("ifHasValidFields", ifHasValidFieldsHelper)
+	t.RegisterHelper("ifRequest", ifRequestHelper)
+
+	t.RegisterHelper("storageOption", storageOptionHelper)
+
+	t.RegisterHelper("accessString", accessStringHelper)
+	t.RegisterHelper("ifHasLengthConstraint", ifHasLengthConstraintHelper)
+	t.RegisterHelper("lengthConstraint", lengthConstraintHelper)
+	t.RegisterHelper("bitName", bitNameHelper)
+	t.RegisterHelper("bitMask", bitMaskHelper)
+	t.RegisterHelper("bitmapType", bitmapTypeHelper)
+	t.RegisterHelper("deviceTypeName", deviceTypeNameHelper)
+	t.RegisterHelper("endpointServers", endpointServersHelper(sp.spec))
+	t.RegisterHelper("endpointClients", endpointClientsHelper(spec))
+}
+
+func numberHelper(value any) raymond.SafeString {
+	switch value := value.(type) {
+	case uint64:
+		return raymond.SafeString(strconv.FormatUint(value, 10))
+	case string:
+		return raymond.SafeString(value)
+	case int64:
+		return raymond.SafeString(strconv.FormatInt(value, 10))
+	case matter.Number:
+		return raymond.SafeString(value.IntString())
+	case *matter.Number:
+		return raymond.SafeString(value.IntString())
+	default:
+		return raymond.SafeString(fmt.Sprintf("unknown number type: %T", value))
+	}
+}
+
+func currentRevisionHelper(revisions matter.Revisions) raymond.SafeString {
+	lastRevision := revisions.MostRecent()
+	if lastRevision != nil {
+		return raymond.SafeString(lastRevision.Number.IntString())
+	}
+	return raymond.SafeString("")
+}
+
+func enumerateHelper[T any](list []T, spec *spec.Specification, options *raymond.Options) raymond.SafeString {
+	var result strings.Builder
+	for i, en := range list {
+		df := options.DataFrame().Copy()
+		df.Set("index", i)
+		df.Set("key", nil)
+		df.Set("first", i == 0)
+		df.Set("last", i == len(list)-1)
+		result.WriteString(options.FnCtxData(en, df))
+	}
+	return raymond.SafeString(result.String())
+}
+
+func ifFabricScopedHelper(a matter.FabricScoping, options *raymond.Options) string {
+	if a == matter.FabricScopingScoped {
+		return options.Fn()
+	}
+	return options.Inverse()
+}
+
+func ifFabricSensitiveHelper(access matter.Access, options *raymond.Options) string {
+	if access.FabricSensitivity == matter.FabricSensitivitySensitive {
+		return options.Fn()
+	}
+	return options.Inverse()
+}
+
+func maxValue(field matter.Field, fs matter.FieldSet) (max types.DataTypeExtreme, ok bool) {
+	if field.Type == nil || field.Type.IsArray() {
+		return
+	}
+	if field.Constraint == nil {
+		return
+	}
+	if !field.Type.HasLength() {
+		switch field.Type.Entity.(type) {
+		case *matter.Enum, *matter.Bitmap:
+			return
+		}
+		if field.Type.BaseType.IsSimple() {
+			return
+		}
+		if sdk.ToUnderlyingType(field.Type.BaseType).IsSimple() {
+			return
+		}
+	}
+	_, max = zap.GetMinMax(matter.NewConstraintContext(&field, fs), field.Constraint)
+	hasNumericMax := max.IsNumeric()
+	if !hasNumericMax {
+		return
+	}
+
+	maxDueToNullable := types.Max(sdk.ToUnderlyingType(sdk.FindBaseType(field.Type)), types.NullabilityNullable).ValueEquals(max)
+	if maxDueToNullable {
+		return
+	}
+	var redundant bool
+	max, redundant = sdk.CheckUnderlyingType(&field, max, types.DataExtremePurposeMaximum)
+	if redundant {
+		return
+	}
+	ok = true
+	return
+}
+
+func ifHasLengthConstraintHelper(field matter.Field, fs matter.FieldSet, options *raymond.Options) string {
+	if _, ok := maxValue(field, fs); ok {
+		return options.Fn()
+	}
+	return options.Inverse()
+}
+
+func lengthConstraintHelper(field matter.Field, fs matter.FieldSet) raymond.SafeString {
+	if max, ok := maxValue(field, fs); ok {
+		return raymond.SafeString(max.ZapString(field.Type))
+	}
+	return raymond.SafeString("")
+}
+
+func ifOptionalHelper(conf conformance.Conformance, options *raymond.Options) string {
+	if !conformance.IsMandatory(conf) {
+		return options.Fn()
+	}
+	return options.Inverse()
+}
+
+func ifNullableHelper(conf matter.Quality, options *raymond.Options) string {
+	if conf.Has(matter.QualityNullable) {
+		return options.Fn()
+	}
+	return options.Inverse()
+}
+
+func ifReadOnlyHelper(conf matter.Access, options *raymond.Options) string {
+	if conf.Write != matter.PrivilegeUnknown {
+		return options.Inverse()
+	}
+	return options.Fn()
+}
+
+func ifHasAccessHelper(a matter.Access, options *raymond.Options) string {
+	if (a.Read != matter.PrivilegeUnknown && a.Read != matter.PrivilegeView) ||
+		(a.Write != matter.PrivilegeUnknown && a.Write != matter.PrivilegeOperate) ||
+		(a.Invoke != matter.PrivilegeUnknown && a.Invoke != matter.PrivilegeOperate) {
+		return options.Fn()
+	}
+	return options.Inverse()
+}
+
+func accessStringHelper(a matter.Access) raymond.SafeString {
+	var list strings.Builder
+	if a.Read != matter.PrivilegeUnknown && a.Read != matter.PrivilegeView {
+		list.WriteString("read: ")
+		list.WriteString(strings.ToLower(a.Read.String()))
+	}
+	if a.Write != matter.PrivilegeUnknown && a.Write != matter.PrivilegeOperate {
+		if list.Len() > 0 {
+			list.WriteString(", ")
+		}
+		list.WriteString("write: ")
+		list.WriteString(strings.ToLower(a.Write.String()))
+	}
+	if a.Invoke != matter.PrivilegeUnknown && a.Invoke != matter.PrivilegeOperate {
+		if list.Len() > 0 {
+			list.WriteString(", ")
+		}
+		list.WriteString("invoke: ")
+		list.WriteString(strings.ToLower(a.Invoke.String()))
+	}
+
+	return raymond.SafeString(list.String())
+}
+
+func ifRequestHelper(s *matter.Command, options *raymond.Options) string {
+	if s.Direction == matter.InterfaceServer {
+		return options.Fn()
+	}
+	return options.Inverse()
+}
+
+func storageOptionHelper(s string) raymond.SafeString {
+	switch s {
+	case "External":
+		return "callback"
+	case "RAM":
+		return "ram     "
+	case "NVM":
+		return "persist "
+	default:
+		return raymond.SafeString(s)
+	}
+}
+
+func descriptionCommentHelper(description string) raymond.SafeString {
+	if len(description) == 0 {
+		return raymond.SafeString("")
+	}
+	var comment strings.Builder
+	var line strings.Builder
+	line.WriteString("/**")
+	words := strings.Fields(description)
+	for _, word := range words {
+		if line.Len() > 100 {
+			comment.WriteString(line.String())
+			comment.WriteRune('\n')
+			line.Reset()
+			line.WriteString("      ")
+		}
+		line.WriteRune(' ')
+		line.WriteString(word)
+	}
+	line.WriteString(" */")
+	comment.WriteString(line.String())
+	comment.WriteRune('\n')
+	return raymond.SafeString(comment.String())
+}
+
+func deviceTypeNameHelper(s string) raymond.SafeString {
+	return raymond.SafeString(strcase.ToSnake(s))
+}

--- a/zap/regen/reader.go
+++ b/zap/regen/reader.go
@@ -1,0 +1,47 @@
+package regen
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"os"
+
+	"github.com/project-chip/alchemy/internal/pipeline"
+	"github.com/project-chip/alchemy/zap"
+)
+
+type Reader struct {
+}
+
+func NewReader() (Reader, error) {
+	return Reader{}, nil
+}
+
+func (p Reader) Name() string {
+	return "Parsing ZAP files"
+}
+
+func (p Reader) Process(cxt context.Context, input *pipeline.Data[struct{}], index int32, total int32) (outputs []*pipeline.Data[*zap.File], extras []*pipeline.Data[struct{}], err error) {
+	slog.Info("reading zap path", "path", input.Path)
+	var contents *os.File
+	contents, err = os.Open(input.Path)
+	if err != nil {
+		return
+	}
+	defer contents.Close()
+
+	decoder := json.NewDecoder(contents)
+
+	decoder.DisallowUnknownFields()
+
+	var zf zap.File
+
+	err = decoder.Decode(&zf)
+	if err != nil {
+		slog.Error("Error reading ZAP path", slog.Any("error", err), slog.String("source", input.Path))
+		return
+	}
+
+	outputs = append(outputs, &pipeline.Data[*zap.File]{Path: input.Path, Content: &zf})
+	return
+}

--- a/zap/regen/render.go
+++ b/zap/regen/render.go
@@ -1,0 +1,319 @@
+package regen
+
+import (
+	"context"
+	"embed"
+	"log/slog"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/mailgun/raymond/v2"
+	"github.com/project-chip/alchemy/asciidoc/parse"
+	"github.com/project-chip/alchemy/internal/handlebars"
+	"github.com/project-chip/alchemy/internal/pipeline"
+	"github.com/project-chip/alchemy/matter"
+	"github.com/project-chip/alchemy/matter/conformance"
+	"github.com/project-chip/alchemy/matter/spec"
+	"github.com/project-chip/alchemy/matter/types"
+	"github.com/project-chip/alchemy/provisional"
+	"github.com/project-chip/alchemy/zap"
+)
+
+//go:embed templates
+var templateFiles embed.FS
+
+type IdlRenderer struct {
+	spec *spec.Specification
+
+	commonAttributes matter.FieldSet
+
+	SuppressEndpoints bool
+}
+
+func NewIdlRenderer(spec *spec.Specification) (IdlRenderer, error) {
+	renderer := IdlRenderer{spec: spec}
+	renderer.commonAttributes = matter.FieldSet{
+		&matter.Field{
+			Name:        "GeneratedCommandList",
+			ID:          matter.NewNumber(65528),
+			Type:        types.NewDataType(types.BaseDataTypeCommandID, types.DataTypeRankList),
+			Access:      matter.Access{Read: matter.PrivilegeView},
+			Conformance: conformance.Set{&conformance.Mandatory{}},
+		},
+		&matter.Field{
+			Name:        "AcceptedCommandList",
+			ID:          matter.NewNumber(65529),
+			Type:        types.NewDataType(types.BaseDataTypeCommandID, types.DataTypeRankList),
+			Access:      matter.Access{Read: matter.PrivilegeView},
+			Conformance: conformance.Set{&conformance.Mandatory{}},
+		},
+		&matter.Field{
+			Name:        "AttributeList",
+			ID:          matter.NewNumber(65531),
+			Type:        types.NewDataType(types.BaseDataTypeAttributeID, types.DataTypeRankList),
+			Access:      matter.Access{Read: matter.PrivilegeView},
+			Conformance: conformance.Set{&conformance.Mandatory{}},
+		},
+		&matter.Field{
+			Name:        "FeatureMap",
+			ID:          matter.NewNumber(65532),
+			Type:        types.NewDataType(types.BaseDataTypeMap32, types.DataTypeRankScalar),
+			Access:      matter.Access{Read: matter.PrivilegeView},
+			Conformance: conformance.Set{&conformance.Mandatory{}},
+		},
+		&matter.Field{
+			Name:        "ClusterRevision",
+			ID:          matter.NewNumber(65533),
+			Type:        types.NewDataType(types.BaseDataTypeUInt16, types.DataTypeRankScalar),
+			Access:      matter.Access{Read: matter.PrivilegeView},
+			Conformance: conformance.Set{&conformance.Mandatory{}},
+		},
+	}
+	return renderer, nil
+}
+
+func (p IdlRenderer) Name() string {
+	return "Writing Matter files"
+}
+
+func (p IdlRenderer) Process(cxt context.Context, input *pipeline.Data[*zap.File], index int32, total int32) (outputs []*pipeline.Data[string], extras []*pipeline.Data[*zap.File], err error) {
+
+	dir := filepath.Dir(input.Path)
+	base := filepath.Base(input.Path)
+	extension := filepath.Ext(base)
+	file := strings.TrimSuffix(base, extension)
+	path := filepath.Join(dir, file+".matter")
+
+	slog.Info("converting zap path", "path", input.Path, "matter", path)
+
+	var endpoints []Endpoint
+	clusters := make(map[*matter.Cluster]*ClusterInfo)
+
+	for _, endpoint := range input.Content.Endpoints {
+		if endpoint.EndpointTypeIndex < 0 || endpoint.EndpointTypeIndex >= len(input.Content.EndpointTypes) {
+			continue
+		}
+		endpointType := input.Content.EndpointTypes[endpoint.EndpointTypeIndex]
+
+		deviceType, ok := p.spec.DeviceTypesByID[uint64(endpointType.DeviceTypeCode)]
+		if !ok {
+			continue
+		}
+		ep := Endpoint{ID: endpoint.EndpointId, EndpointType: endpointType}
+		ep.DeviceType = deviceType
+		for _, clusterRef := range ep.Clusters {
+			c, ok := p.spec.ClustersByID[uint64(clusterRef.Code)]
+			if !ok {
+				slog.Warn("Unrecognized cluster code", slog.String("path", input.Path), slog.Int("clusterCode", clusterRef.Code))
+				continue
+			}
+			ci := &ClusterInfo{Cluster: c}
+			clusters[c] = ci
+			switch clusterRef.Side {
+			case "server":
+				ep.Servers = append(ep.Servers, ci)
+			case "client":
+				ep.Clients = append(ep.Clients, ci)
+			}
+		}
+		endpoints = append(endpoints, ep)
+	}
+
+	clusterList := make([]*ClusterInfo, 0, len(clusters))
+	clusterEntities := make(map[*matter.Cluster]map[types.Entity]struct{})
+	globalEntities := make(map[types.Entity]bool)
+	for entity := range p.spec.GlobalObjects {
+		globalEntities[entity] = false
+	}
+	for cluster, ci := range clusters {
+		clusterList = append(clusterList, ci)
+		clusterEntities[cluster] = make(map[types.Entity]struct{})
+	}
+
+	slices.SortFunc(clusterList, func(a *ClusterInfo, b *ClusterInfo) int {
+		return a.Cluster.ID.Compare(b.Cluster.ID)
+	})
+
+	var globalEnums []*matter.Enum
+	var globalStructs []*matter.Struct
+	var globalBitmaps []*matter.Bitmap
+	namespaces := make(map[string]*matter.Namespace)
+
+	spec.TraverseEntities(p.spec, func(parentCluster *matter.Cluster, parent, entity types.Entity) parse.SearchShould {
+
+		ce, ok := clusterEntities[parentCluster]
+		if !ok {
+			return parse.SearchShouldSkip
+		}
+		if !entityShouldBeIncluded(entity) || !entityShouldBeIncluded(parent) {
+			return parse.SearchShouldSkip
+		}
+		_, isDirectChildOfCluster := parent.(*matter.Cluster)
+		switch entity := entity.(type) {
+		case *matter.Namespace:
+			field, ok := parent.(*matter.Field)
+			if ok {
+				_, existing := namespaces[field.Name]
+				if !existing {
+					namespaces[field.Name] = entity
+				}
+			}
+			return parse.SearchShouldContinue
+		case *matter.Bitmap, *matter.Enum, *matter.Struct:
+			if isDirectChildOfCluster && !forceIncludeEntity(p.spec, parentCluster, entity) {
+				// We won't include these entities if they're only referenced by the cluster itself, not any of its attributes, commands or events
+				return parse.SearchShouldSkip
+			}
+		}
+		if _, isGlobal := p.spec.GlobalObjects[entity]; isGlobal {
+			globalEntities[entity] = true
+			return parse.SearchShouldContinue
+		}
+		ce[entity] = struct{}{}
+		globalEntities[entity] = false
+		return parse.SearchShouldContinue
+	})
+
+	for entity, isGlobal := range globalEntities {
+		if !isGlobal {
+			continue
+		}
+		if provisional.Check(p.spec, entity, entity) == provisional.StateUnreferenced {
+			continue
+		}
+		switch entity := entity.(type) {
+		case *matter.Bitmap:
+			globalBitmaps = append(globalBitmaps, entity)
+		case *matter.Enum:
+			globalEnums = append(globalEnums, entity)
+		case *matter.Struct:
+			globalStructs = append(globalStructs, entity)
+
+		default:
+			slog.Warn("Unexpected entity in global entities", matter.LogEntity("entity", entity))
+		}
+	}
+
+	for fieldName, ns := range namespaces {
+		en := matter.NewEnum(ns.Source(), ns.Parent())
+		if strings.HasSuffix(fieldName, "Tag") {
+			en.Name = fieldName
+		} else {
+			en.Name = fieldName + "Tag"
+		}
+		en.Type = types.NewDataType(types.BaseDataTypeEnum8, types.DataTypeRankScalar)
+		for _, tag := range ns.SemanticTags {
+			nst := matter.NewEnumValue(tag.Source(), en)
+			nst.Name = tag.Name
+			nst.Value = tag.ID
+			en.Values = append(en.Values, nst)
+		}
+		globalEnums = append(globalEnums, en)
+	}
+
+	for _, clusterInfo := range clusterList {
+		ce, ok := clusterEntities[clusterInfo.Cluster]
+		if !ok {
+			continue
+		}
+		for e := range ce {
+			isGlobal := globalEntities[e]
+			if isGlobal {
+				continue
+			}
+			switch e := e.(type) {
+			case *matter.Bitmap:
+				clusterInfo.ReferencedBitmaps = append(clusterInfo.ReferencedBitmaps, e)
+			case *matter.Enum:
+				clusterInfo.ReferencedEnums = append(clusterInfo.ReferencedEnums, e)
+			case *matter.Struct:
+				clusterInfo.ReferencedStructs = append(clusterInfo.ReferencedStructs, e)
+			}
+		}
+	}
+
+	tc := map[string]any{
+		"bitmaps":   globalBitmaps,
+		"enums":     globalEnums,
+		"structs":   globalStructs,
+		"clusters":  clusterList,
+		"endpoints": endpoints,
+	}
+	if p.SuppressEndpoints {
+		tc["endpoints"] = nil
+	}
+
+	var t *raymond.Template
+	t, err = p.loadTemplate(p.spec)
+	if err != nil {
+		return
+	}
+
+	var out string
+	out, err = t.Exec(tc)
+	if err != nil {
+		slog.Error("error rendering matter template", slog.Any("err", err))
+		return
+	}
+	outputs = append(outputs, pipeline.NewData(path, out))
+	return
+}
+
+var template pipeline.Once[*raymond.Template]
+
+func (sp *IdlRenderer) loadTemplate(spec *spec.Specification) (*raymond.Template, error) {
+	t, err := template.Do(func() (*raymond.Template, error) {
+
+		ov := handlebars.NewOverlay("", templateFiles, "templates")
+		err := ov.Flush()
+		if err != nil {
+			slog.Error("Error flushing embedded templates", slog.Any("error", err))
+		}
+		t, err := handlebars.LoadTemplate("{{> matter}}", ov)
+		if err != nil {
+			return nil, err
+		}
+
+		handlebars.RegisterCommonHelpers(t)
+
+		return t, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	t = t.Clone()
+	sp.registerIdlHelpers(t, spec)
+	return t, nil
+}
+
+func forceIncludeEntity(spec *spec.Specification, cluster *matter.Cluster, e types.Entity) bool {
+	if e, ok := e.(*matter.Enum); ok {
+		if strings.EqualFold(e.Name, "StatusCode") || strings.EqualFold(e.Name, "StatusCodeEnum") || strings.EqualFold(e.Name, "ModeTag") {
+			return true
+		}
+	}
+	doc, ok := spec.DocRefs[cluster]
+	if !ok {
+		return false
+	}
+	errata := spec.Errata.Get(doc.Path.Relative)
+	if errata == nil || errata.SDK.ExtraTypes == nil {
+		return false
+	}
+	switch e := e.(type) {
+	case *matter.Bitmap:
+		if _, ok := errata.SDK.ExtraTypes.Bitmaps[e.Name]; ok {
+			return true
+		}
+	case *matter.Enum:
+		if _, ok := errata.SDK.ExtraTypes.Enums[e.Name]; ok {
+			return true
+		}
+	case *matter.Struct:
+		if _, ok := errata.SDK.ExtraTypes.Structs[e.Name]; ok {
+			return true
+		}
+	}
+	return false
+}

--- a/zap/regen/targeter.go
+++ b/zap/regen/targeter.go
@@ -1,0 +1,28 @@
+package regen
+
+import (
+	"context"
+	"io/fs"
+	"path/filepath"
+)
+
+func Targeter(sdkRoot string) func(cxt context.Context) ([]string, error) {
+	return func(cxt context.Context) ([]string, error) {
+		return getZapPaths(sdkRoot)
+	}
+}
+
+func getZapPaths(sdkRoot string) (zapPaths []string, err error) {
+	zapPaths = append(zapPaths, filepath.Join(sdkRoot, "src/controller/data_model/controller-clusters.zap"))
+	srcRoot := filepath.Join(sdkRoot, "/examples/")
+	err = filepath.WalkDir(srcRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if filepath.Ext(path) == ".zap" {
+			zapPaths = append(zapPaths, path)
+		}
+		return nil
+	})
+	return
+}

--- a/zap/regen/templates/access.handlebars
+++ b/zap/regen/templates/access.handlebars
@@ -1,0 +1,1 @@
+{{#ifHasAccess access}}access({{accessString access}}) {{/ifHasAccess ~}}

--- a/zap/regen/templates/attribute.handlebars
+++ b/zap/regen/templates/attribute.handlebars
@@ -1,0 +1,6 @@
+{{#if provisional}}provisional {{/if ~}}
+{{#ifReadOnly attribute.Access}}readonly {{/ifReadOnly ~}}
+attribute {{> access access=attribute.Access ~}}{{#ifOptional attribute.Conformance}}optional {{/ifOptional ~}}
+{{#ifNullable attribute.Quality}}nullable {{/ifNullable ~}}
+{{fieldType attribute cluster.Attributes ~}}
+{{#ifHasLengthConstraint attribute cluster.Attributes}}<{{lengthConstraint attribute cluster.Attributes}}>{{/ifHasLengthConstraint}} {{asLowerCamelCase attribute.Name}}{{#fieldIsArray attribute.Type}}[]{{/fieldIsArray}} = {{number attribute.ID}};

--- a/zap/regen/templates/bitmap.handlebars
+++ b/zap/regen/templates/bitmap.handlebars
@@ -1,0 +1,6 @@
+{{#if provisional}}provisional {{/if ~}}
+bitmap {{asUpperCamelCase bitmap.Name}} : {{bitmapType bitmap}} {
+{{#bitmapBits bitmap}}
+  {{> bitmap_bit cluster=cluster bitmap=bitmap bit=this}}
+{{/bitmapBits}}
+}

--- a/zap/regen/templates/bitmap_bit.handlebars
+++ b/zap/regen/templates/bitmap_bit.handlebars
@@ -1,0 +1,1 @@
+k{{bitName bit}} = {{bitMask bit}}{{#upperCamelCaseDiffers value.Name}} [spec_name = "{{value.Name}}"]{{/upperCamelCaseDiffers}};

--- a/zap/regen/templates/bitmap_bit.handlebars
+++ b/zap/regen/templates/bitmap_bit.handlebars
@@ -1,1 +1,1 @@
-k{{bitName bit}} = {{bitMask bit}}{{#upperCamelCaseDiffers value.Name}} [spec_name = "{{value.Name}}"]{{/upperCamelCaseDiffers}};
+k{{bitName bit}} = {{bitMask bit}}{{#upperCamelCaseDiffers bit.Name}} [spec_name = "{{bit.Name}}"]{{/upperCamelCaseDiffers}};

--- a/zap/regen/templates/cluster.handlebars
+++ b/zap/regen/templates/cluster.handlebars
@@ -1,0 +1,42 @@
+{{descriptionComment clusterInfo.Cluster.Description ~}}
+{{#if provisional}}provisional {{/if ~}}
+cluster {{asUpperCamelCaseIgnoreAcronyms clusterInfo.Cluster.Name}} = {{number clusterInfo.Cluster.ID}} {
+  revision {{currentRevision clusterInfo.Cluster.Revisions}};
+{{#enums clusterInfo.ReferencedEnums}}
+
+  {{> enum cluster=clusterInfo.Cluster shared=@shared enum=this provisional=@provisional shared=@shared}}
+{{/enums}}
+{{#bitmaps clusterInfo }}
+
+  {{> bitmap cluster=clusterInfo.Cluster bitmap=this provisional=@provisional shared=@shared}}
+{{/bitmaps}}
+{{#structs clusterInfo.ReferencedStructs}}
+
+  {{> struct cluster=clusterInfo.Cluster struct=this provisional=@provisional shared=@shared}}
+{{/structs}}
+{{#events clusterInfo.Cluster}}
+
+  {{> event cluster=clusterInfo.Cluster event=this provisional=@provisional }}
+{{/events}}
+
+{{#attributes clusterInfo.Cluster}}
+  {{> attribute cluster=cluster  attribute=this provisional=@provisional}}
+{{/attributes}}
+{{#commands clusterInfo.Cluster.Commands}}
+{{#ifRequest this ~}}
+{{#ifHasValidFields this.Fields}}
+
+  {{> request cluster=clusterInfo.Cluster command=this provisional=@provisional }}
+{{/ifHasValidFields}}
+{{else}}
+
+  {{> response cluster=clusterInfo.Cluster command=this provisional=@provisional}}
+{{/ifRequest}}
+{{/commands}}
+{{#if clusterInfo.Cluster.Commands}}
+
+{{#requests clusterInfo.Cluster.Commands}}
+  {{> command cluster=cluster command=this provisional=@provisional}}
+{{/requests}}
+{{/if}}
+}

--- a/zap/regen/templates/command.handlebars
+++ b/zap/regen/templates/command.handlebars
@@ -1,0 +1,5 @@
+{{descriptionComment command.Description ~}}
+{{#if provisional}}provisional {{/if ~}}
+{{#ifFabricScoped command.Access.FabricScoping}}fabric {{/ifFabricScoped ~}}
+{{#isTimed command}}timed {{/isTimed ~}}
+command {{> access access=event.Access ~}}{{asUpperCamelCase command.Name}}({{#ifHasValidFields command.Fields}}{{requestName command}}Request{{/ifHasValidFields}}): {{responseName command}} = {{number command.ID}};

--- a/zap/regen/templates/command.handlebars
+++ b/zap/regen/templates/command.handlebars
@@ -2,4 +2,4 @@
 {{#if provisional}}provisional {{/if ~}}
 {{#ifFabricScoped command.Access.FabricScoping}}fabric {{/ifFabricScoped ~}}
 {{#isTimed command}}timed {{/isTimed ~}}
-command {{> access access=event.Access ~}}{{asUpperCamelCase command.Name}}({{#ifHasValidFields command.Fields}}{{requestName command}}Request{{/ifHasValidFields}}): {{responseName command}} = {{number command.ID}};
+command {{> access access=command.Access ~}}{{asUpperCamelCase command.Name}}({{#ifHasValidFields command.Fields}}{{requestName command}}Request{{/ifHasValidFields}}): {{responseName command}} = {{number command.ID}};

--- a/zap/regen/templates/endpoint.handlebars
+++ b/zap/regen/templates/endpoint.handlebars
@@ -1,0 +1,28 @@
+endpoint {{endpoint.ID}} {
+  device type {{deviceTypeName endpoint.DeviceTypeName}} = {{endpoint.DeviceTypeCode}}, version {{currentRevision endpoint.DeviceType.Revisions}};
+{{#if endpoint.Clients}}
+
+{{#each endpoint.Clients}}
+  binding cluster {{asUpperCamelCaseIgnoreAcronyms this.Cluster.Name}};
+{{/each}}
+{{/if}}
+{{#endpointServers endpoint}}
+
+  server cluster {{asUpperCamelCase this.Name}} {
+{{#each this.Events}}
+    emits event {{asUpperCamelCase this.Name}};
+{{/each}}
+{{#if this.Attributes}}
+{{#each this.Attributes}}
+    {{storageOption this.StorageOption}} attribute {{asLowerCamelCase this.Name}}{{#if this.DefaultValue}} default = {{this.DefaultValue}}{{/if}};
+{{/each}}
+{{/if}}
+{{#if this.Commands}}
+
+{{#each this.Commands}}
+    handle command {{asUpperCamelCase this.Name}};
+{{/each}}
+{{/if}}
+  }
+{{/endpointServers}}
+}

--- a/zap/regen/templates/enum.handlebars
+++ b/zap/regen/templates/enum.handlebars
@@ -1,0 +1,7 @@
+{{#if provisional}}provisional {{/if ~}}
+{{#if shared}}shared {{/if ~}}
+enum {{asUpperCamelCase enum.Name}} : {{enum.Type.Name}} {
+{{#each enum.Values}}
+  {{> enum_value cluster=cluster enum=enum value=this}}
+{{/each}}
+}

--- a/zap/regen/templates/enum_value.handlebars
+++ b/zap/regen/templates/enum_value.handlebars
@@ -1,0 +1,1 @@
+k{{asUpperCamelCase value.Name}} = {{number value.Value}}{{#upperCamelCaseDiffers value.Name}} [spec_name = "{{value.Name}}"]{{/upperCamelCaseDiffers}};

--- a/zap/regen/templates/event.handlebars
+++ b/zap/regen/templates/event.handlebars
@@ -1,0 +1,7 @@
+{{#if provisional}}provisional {{/if ~}}
+{{#ifFabricSensitive event.Access}}fabric_sensitive {{/ifFabricSensitive ~}}
+{{toLower event.Priority}} event {{> access access=event.Access ~}}{{asUpperCamelCase event.Name}} = {{number event.ID}} {
+{{#eventFields event}}
+  {{> field cluster=cluster event=event field=this fieldset=event.Fields}}
+{{/eventFields}}
+}

--- a/zap/regen/templates/field.handlebars
+++ b/zap/regen/templates/field.handlebars
@@ -1,0 +1,5 @@
+{{#ifOptional field.Conformance}}optional {{/ifOptional ~}}
+{{#ifNullable field.Quality}}nullable {{/ifNullable ~}}
+{{#ifFabricSensitive field.Access}}fabric_sensitive {{/ifFabricSensitive ~}}
+{{fieldType field fieldset ~}}
+{{#ifHasLengthConstraint field fieldset}}<{{lengthConstraint field fieldset}}>{{/ifHasLengthConstraint}} {{asLowerCamelCase field.Name}}{{#fieldIsArray field.Type}}[]{{/fieldIsArray}} = {{number field.ID}};

--- a/zap/regen/templates/matter.handlebars
+++ b/zap/regen/templates/matter.handlebars
@@ -1,0 +1,24 @@
+// This IDL was generated automatically by Alchemy.
+
+{{#enums enums}}
+
+{{> enum enum=this shared=shared provisional=@provisional}}
+{{/enums}}
+{{#bitmaps nil bitmaps}}
+
+{{> bitmap bitmap=this shared=shared provisional=@provisional}}
+{{/bitmaps}}
+{{#structs structs}}
+
+{{> struct struct=this shared=shared provisional=@provisional}}
+{{/structs}}
+{{#clusters clusters}}
+
+{{> cluster clusterInfo=this  provisional=@provisional}}
+{{/clusters}}
+
+{{#each endpoints}}
+{{> endpoint endpoint=this  provisional=@provisional}}
+{{/each}}
+
+

--- a/zap/regen/templates/matter.handlebars
+++ b/zap/regen/templates/matter.handlebars
@@ -4,7 +4,7 @@
 
 {{> enum enum=this shared=shared provisional=@provisional}}
 {{/enums}}
-{{#bitmaps nil bitmaps}}
+{{#bitmaps bitmaps}}
 
 {{> bitmap bitmap=this shared=shared provisional=@provisional}}
 {{/bitmaps}}

--- a/zap/regen/templates/request.handlebars
+++ b/zap/regen/templates/request.handlebars
@@ -1,0 +1,5 @@
+request struct {{requestName command}}Request {
+{{#commandFields command}}
+  {{> field cluster=cluster command=command field=this fieldset=command.Fields}}
+{{/commandFields}}
+}

--- a/zap/regen/templates/response.handlebars
+++ b/zap/regen/templates/response.handlebars
@@ -1,0 +1,5 @@
+response struct {{requestName command}} = {{number command.ID}} {
+{{#commandFields command}}
+  {{> field cluster=cluster command=command field=this fieldset=command.Fields}}
+{{/commandFields}}
+}

--- a/zap/regen/templates/struct.handlebars
+++ b/zap/regen/templates/struct.handlebars
@@ -1,0 +1,8 @@
+{{#if provisional}}provisional {{/if ~}}
+{{#ifFabricScoped struct.FabricScoping}}fabric_scoped {{/ifFabricScoped ~}}
+{{#if shared}}shared {{/if ~}}
+struct {{asUpperCamelCase struct.Name}} {
+{{#structFields struct}}
+  {{> field cluster=cluster struct=struct field=this fieldset=struct.Fields}}
+{{/structFields}}
+}


### PR DESCRIPTION
This pull request introduces ZAP Code Generation / Regeneration Tooling to the alchemy CLI utility. It adds support for parsing ZAP files and translating them into the Matter IDL (.matter) format, as well as generating synthetic controller-clusters definition files directly from the Matter specification. 

**Key Changes:**

1. CLI Commands:
- Grouped ZAP commands under a root "zap" command.
- Renamed the legacy ZAP command to "zap xml".
- Added a new "zap regen" command to read ZAP template input files, render them, and output generated .matter files.
- Added a new "zap controller-clusters" command to generate a synthetic controller-clusters.matter file containing all clusters defined in the specification.

2. Renderer & Templates:
- Added the zap/regen package implementing the IdlRenderer and template loading.
- Added Handlebars templates for access, attributes, bitmaps, clusters, commands, endpoints, enums, events, fields, matter, requests, responses, and structs.
- Registered toLower and toUpper Handlebars helpers.

3. Specification Traversal:
- Added TraverseEntities to matter/spec/refs.go to allow traversing the hierarchical structure of a specification.
- Updated BuildClusterReferences and BuildDataTypeReferences to utilize the new traversal logic.

4. Matter Models & Data Types:
- Added json.go models for parsing ZAP .zap file structures.
- Added HasLength to BaseDataType and DataType.
- Added Iterate to EntitySet.
- Added CaseWithAcronyms and CamelCaseWithAcronyms to case.go to preserve acronym formatting.
- Added underlying types for Matter-specific types (e.g. FabricIndex, GroupID, NodeID) in ToUnderlyingType.
