### PR TITLE
Generate Matter IDL in deterministic order

### DIFF
--- a/zap/regen/bitmap.go
+++ b/zap/regen/bitmap.go
@@ -120,6 +120,17 @@ func filterBits(bm *matter.Bitmap) (bits matter.BitSet) {
 		}
 		bits = append(bits, b)
 	}
+	slices.SortStableFunc(bits, func(a, b matter.Bit) int {
+		maskA, _ := a.Mask()
+		maskB, _ := b.Mask()
+		if maskA < maskB {
+			return -1
+		}
+		if maskA > maskB {
+			return 1
+		}
+		return 0
+	})
 	return
 }
 

--- a/zap/regen/cluster.go
+++ b/zap/regen/cluster.go
@@ -73,6 +73,9 @@ func clusterEventsHelper(spec *spec.Specification) func(cluster matter.Cluster, 
 	return func(cluster matter.Cluster, options *raymond.Options) raymond.SafeString {
 		events := make(matter.EventSet, len(cluster.Events))
 		copy(events, cluster.Events)
+		slices.SortStableFunc(events, func(a *matter.Event, b *matter.Event) int {
+			return a.ID.Compare(b.ID)
+		})
 		return enumerateEntitiesHelper(events, spec, options)
 	}
 }

--- a/zap/regen/command.go
+++ b/zap/regen/command.go
@@ -2,6 +2,7 @@ package regen
 
 import (
 	"slices"
+	"strings"
 
 	"github.com/mailgun/raymond/v2"
 	"github.com/project-chip/alchemy/matter"
@@ -25,11 +26,7 @@ func commandsHelper(spec *spec.Specification) func(commands matter.CommandSet, o
 			if cmp != 0 {
 				return cmp
 			}
-			if a.Direction == matter.InterfaceServer {
-				return 1
-			} else {
-				return 0
-			}
+			return strings.Compare(a.Name, b.Name)
 		})
 		return enumerateEntitiesHelper(sortedCommands, spec, options)
 	}
@@ -41,6 +38,9 @@ func commandFieldsHelper(spec *spec.Specification) func(matter.Command, *raymond
 		if cmd.Access.FabricSensitivity == matter.FabricSensitivitySensitive {
 			fields = append(fields, &matter.Field{ID: matter.NewNumber(254), Name: "FabricIndex", Type: types.NewDataType(types.BaseDataTypeFabricIndex, types.DataTypeRankScalar), Conformance: conformance.Set{&conformance.Mandatory{}}})
 		}
+		slices.SortStableFunc(fields, func(a *matter.Field, b *matter.Field) int {
+			return a.ID.Compare(b.ID)
+		})
 		return enumerateEntitiesHelper(fields, spec, options)
 	}
 }

--- a/zap/regen/enum.go
+++ b/zap/regen/enum.go
@@ -16,6 +16,11 @@ func enumsHelper(spec *spec.Specification) func(enums matter.EnumSet, options *r
 		slices.SortStableFunc(sortedEnums, func(a *matter.Enum, b *matter.Enum) int {
 			return strings.Compare(a.Name, b.Name)
 		})
+		for _, en := range sortedEnums {
+			slices.SortStableFunc(en.Values, func(a *matter.EnumValue, b *matter.EnumValue) int {
+				return a.Value.Compare(b.Value)
+			})
+		}
 		return enumerateEntitiesHelper(sortedEnums, spec, options)
 	}
 }

--- a/zap/regen/field.go
+++ b/zap/regen/field.go
@@ -1,6 +1,8 @@
 package regen
 
 import (
+	"slices"
+
 	"github.com/mailgun/raymond/v2"
 	"github.com/project-chip/alchemy/matter"
 	"github.com/project-chip/alchemy/matter/conformance"
@@ -49,6 +51,9 @@ func structFieldsHelper(spec *spec.Specification) func(s matter.Struct, options 
 			fabricIndex.SetParent(&s)
 			fields = append(fields, fabricIndex)
 		}
+		slices.SortStableFunc(fields, func(a *matter.Field, b *matter.Field) int {
+			return a.ID.Compare(b.ID)
+		})
 		return enumerateEntitiesHelper(fields, spec, options)
 	}
 }
@@ -61,6 +66,9 @@ func eventFieldsHelper(spec *spec.Specification) func(e matter.Event, options *r
 			fabricIndex.SetParent(&e)
 			fields = append(fields, fabricIndex)
 		}
+		slices.SortStableFunc(fields, func(a *matter.Field, b *matter.Field) int {
+			return a.ID.Compare(b.ID)
+		})
 		return enumerateEntitiesHelper(fields, spec, options)
 	}
 }

--- a/zap/regen/render.go
+++ b/zap/regen/render.go
@@ -212,6 +212,18 @@ func (p IdlRenderer) Process(cxt context.Context, input *pipeline.Data[*zap.File
 		globalEnums = append(globalEnums, en)
 	}
 
+	slices.SortFunc(globalEnums, func(a, b *matter.Enum) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+
+	slices.SortFunc(globalBitmaps, func(a, b *matter.Bitmap) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+
+	slices.SortFunc(globalStructs, func(a, b *matter.Struct) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+
 	for _, clusterInfo := range clusterList {
 		ce, ok := clusterEntities[clusterInfo.Cluster]
 		if !ok {


### PR DESCRIPTION
# Description
This PR introduces comprehensive, deterministic sorting rules to the ZAP IDL generation tools (`zap regen` and `zap controller-clusters`). This eliminates arbitrary diffs caused by non-deterministic data structures (like Go map iterations) and differences in specification document ordering, ensuring generated `.matter` files are 100% reproducible.

# Testing
* Verified all Go tests compile and pass successfully.
* Manually ran code generation on Matter clusters and verified the resulting `.matter` file structures are deterministically sorted.

# Implemented sort logic:

## 1. Top-Level Section Sequence
When rendering the complete Matter IDL file, definitions are sequenced as follows:
1. **Global Definitions** (Global Enums, Global Bitmaps, Global Structs).
2. **Cluster Definitions** (The list of server and client clusters).
3. **Endpoint Definitions** (Endpoints mapping to cluster instances, unless suppressed).


## 2. Global Definitions Sorting
All top-level global entities parsed from the specification are sorted alphabetically by their name before rendering:

* **Global Enums**: Sorted alphabetically by enum `Name`.
* **Global Bitmaps**: Sorted alphabetically by bitmap `Name`.
* **Global Structs**: Sorted alphabetically by struct `Name`.

Within each global entity:
* **Enum values**: Sorted numerically by their ID/value in ascending order.
* **Bitmap bits**: Sorted numerically by their bitmask value in ascending order.
* **Struct fields**: Sorted numerically by their field ID in ascending order.



## 3. Cluster Scope Section Layout
For each cluster definition (`cluster <Name> = <ID> { ... }`), the internal sections are arranged in the following sequence:

1. **Enums**
2. **Bitmaps**
3. **Structs**
4. **Events**
5. **Attributes**
6. **Request & Response Structs** (Command payload structs)
7. **Command Declarations** (Commands exposed by the cluster)


## 4. Cluster-Specific Elements Sorting

Within each cluster, elements of each category are sorted as follows:

### A. Enums
* **Enum List**: Sorted alphabetically by enum `Name`.
* **Enum Values / Entries**: Sorted numerically by value (ID) in ascending order.

### B. Bitmaps
* **Bitmap List**: Sorted alphabetically by bitmap `Name`.
* **Bitmap Bits**: Sorted numerically by bitmask value in ascending order.

### C. Structs
* **Struct List**: Sorted by **Scoping** first, then **Name**:
  1. **Regular Structs** (`struct <Name>`) are rendered first.
  2. **Fabric-Scoped Structs** (`fabric_scoped struct <Name>`) are rendered last.
  3. Within each of the two groups, structs are sorted alphabetically by `Name`.
* **Struct Fields**: Sorted numerically by field ID in ascending order.

### D. Events
* **Event List**: Sorted numerically by event ID in ascending order.
* **Event Fields**: Sorted numerically by field ID in ascending order.

### E. Attributes
* **Attribute List**: Sorted numerically by attribute ID in ascending order.

### F. Request & Response Structs (Command Payloads)
Request and response structs are generated by iterating over the cluster's commands:
* **Command List**: Sorted numerically by command ID in ascending order. If two commands share the same ID (e.g. a request command `Arm` and response command `ArmResponse`), they are sorted **alphabetically by command Name** (placing `Arm` before `ArmResponse`).
* **Command Fields**: Sorted numerically by field ID in ascending order.

### G. Command Declarations (at the end of the cluster)
* **Command Declarations**: Sorted numerically by command ID in ascending order.


## 5. Field Member ID Ordering Details (IDs 250+)
For all fields inside Structs, Events, and Commands, the elements are sorted numerically by field ID. 

Since ZAP-injected metadata fields (such as `FabricIndex`) have a fixed field ID of `254` (the maximum allowed ID value), they naturally sort to the **very end** of the fields list inside any struct, event, or command definition where they are present.
