### PR TITLE
Matter idl gen additional features

### DIFF
--- a/cmd/cli/idl.go
+++ b/cmd/cli/idl.go
@@ -27,7 +27,7 @@ type IDLRegen struct {
 	spec.ParserOptions         `embed:""`
 	spec.FilterOptions         `embed:""`
 	sdk.SDKOptions             `embed:""`
-	SuppressProvisional        string `name:"suppress-provisional" help:"Suppress rendering of provisional elements" default:"none" enum:"none,all,keep-existing"`
+	SuppressProvisional        string `name:"suppress-provisional" help:"Suppress rendering of provisional elements" default:"all" enum:"none,all,keep-existing"`
 }
 
 func (z *IDLRegen) Run(cc *Context) (err error) {
@@ -88,7 +88,7 @@ type IDLControllerClusters struct {
 	files.OutputOptions        `embed:""`
 	spec.ParserOptions         `embed:""`
 	Output                     string `name:"output" placeholder:"path" help:"Output file or directory for controller-clusters.matter" optional:"" default:"controller-clusters.matter"`
-	SuppressProvisional        string `name:"suppress-provisional" help:"Suppress rendering of provisional elements" default:"none" enum:"none,all,keep-existing"`
+	SuppressProvisional        string `name:"suppress-provisional" help:"Suppress rendering of provisional elements" default:"all" enum:"none,all,keep-existing"`
 }
 
 func (z *IDLControllerClusters) Run(cc *Context) (err error) {

--- a/cmd/cli/idl.go
+++ b/cmd/cli/idl.go
@@ -38,7 +38,7 @@ func (z *IDLRegen) Run(cc *Context) (err error) {
 		return
 	}
 
-	err = sdk.ApplyErrata(specification)
+	err = sdk.ApplyErrata(specification, sdk.WithSkipSharedEntities(true))
 	if err != nil {
 		return
 	}
@@ -98,7 +98,7 @@ func (z *IDLControllerClusters) Run(cc *Context) (err error) {
 		return
 	}
 
-	err = sdk.ApplyErrata(specification)
+	err = sdk.ApplyErrata(specification, sdk.WithSkipSharedEntities(true))
 	if err != nil {
 		return
 	}

--- a/errata/merge.go
+++ b/errata/merge.go
@@ -287,6 +287,7 @@ func (t *SDKType) Merge(other *SDKType) {
 	}
 	t.Attributes = mergeSDKTypeMap(t.Attributes, other.Attributes)
 	t.Commands = mergeSDKTypeMap(t.Commands, other.Commands)
+	t.Events = mergeSDKTypeMap(t.Events, other.Events)
 }
 
 func mergeSDKTypeList(target, source []*SDKType) []*SDKType {

--- a/errata/sdk.go
+++ b/errata/sdk.go
@@ -115,6 +115,7 @@ type SDKType struct {
 
 	Attributes map[string]*SDKType `yaml:"attributes,omitempty"`
 	Commands   map[string]*SDKType `yaml:"commands,omitempty"`
+	Events     map[string]*SDKType `yaml:"events,omitempty"`
 }
 
 type SDKTypeCollection map[string]*SDKType

--- a/idl/bitmap.go
+++ b/idl/bitmap.go
@@ -24,7 +24,7 @@ func clusterBitmapsHelper(spec *spec.Specification, filter ProvisionalFilter) fu
 			cluster := val.Cluster
 			if cluster != nil && cluster.Features != nil {
 				if len(filterBits(spec, filter, &cluster.Features.Bitmap)) > 0 {
-					features := cluster.Features.Bitmap.Clone()
+					features := cluster.Features.Bitmap.CloneTo(cluster.Features.Bitmap.Parent())
 					features.Name = "Feature"
 					bitmaps = append(bitmaps, features)
 				}
@@ -39,7 +39,7 @@ func clusterBitmapsHelper(spec *spec.Specification, filter ProvisionalFilter) fu
 				cluster := val.Cluster
 				if cluster != nil && cluster.Features != nil {
 					if len(filterBits(spec, filter, &cluster.Features.Bitmap)) > 0 {
-						features := cluster.Features.Bitmap.Clone()
+						features := cluster.Features.Bitmap.CloneTo(cluster.Features.Bitmap.Parent())
 						features.Name = "Feature"
 						bitmaps = append(bitmaps, features)
 					}

--- a/idl/command.go
+++ b/idl/command.go
@@ -20,9 +20,15 @@ func commandsHelper(spec *spec.Specification, filter ProvisionalFilter) func(com
 			}
 			sortedCommands = append(sortedCommands, cmd)
 		}
+		serverCommandIDs := make(map[string]*matter.Number)
+		for _, c := range commands {
+			if c.Direction == matter.InterfaceServer && c.Response != nil && c.Response.Name != "" {
+				serverCommandIDs[c.Response.Name] = c.ID
+			}
+		}
 		slices.SortStableFunc(sortedCommands, func(a *matter.Command, b *matter.Command) int {
-			aID := getSortID(a, commands)
-			bID := getSortID(b, commands)
+			aID := getSortID(a, serverCommandIDs)
+			bID := getSortID(b, serverCommandIDs)
 			cmp := aID.Compare(bID)
 			if cmp != 0 {
 				return cmp
@@ -33,12 +39,10 @@ func commandsHelper(spec *spec.Specification, filter ProvisionalFilter) func(com
 	}
 }
 
-func getSortID(cmd *matter.Command, commands matter.CommandSet) *matter.Number {
+func getSortID(cmd *matter.Command, serverCommandIDs map[string]*matter.Number) *matter.Number {
 	if cmd.Direction == matter.InterfaceClient {
-		for _, c := range commands {
-			if c.Direction == matter.InterfaceServer && c.Response != nil && c.Response.Name == cmd.Name {
-				return c.ID
-			}
+		if id, ok := serverCommandIDs[cmd.Name]; ok {
+			return id
 		}
 	}
 	return cmd.ID

--- a/idl/command.go
+++ b/idl/command.go
@@ -21,7 +21,9 @@ func commandsHelper(spec *spec.Specification, filter ProvisionalFilter) func(com
 			sortedCommands = append(sortedCommands, cmd)
 		}
 		slices.SortStableFunc(sortedCommands, func(a *matter.Command, b *matter.Command) int {
-			cmp := a.ID.Compare(b.ID)
+			aID := getSortID(a, commands)
+			bID := getSortID(b, commands)
+			cmp := aID.Compare(bID)
 			if cmp != 0 {
 				return cmp
 			}
@@ -29,6 +31,17 @@ func commandsHelper(spec *spec.Specification, filter ProvisionalFilter) func(com
 		})
 		return enumerateEntitiesHelper(sortedCommands, spec, filter, options)
 	}
+}
+
+func getSortID(cmd *matter.Command, commands matter.CommandSet) *matter.Number {
+	if cmd.Direction == matter.InterfaceClient {
+		for _, c := range commands {
+			if c.Direction == matter.InterfaceServer && c.Response != nil && c.Response.Name == cmd.Name {
+				return c.ID
+			}
+		}
+	}
+	return cmd.ID
 }
 
 func commandFieldsHelper(spec *spec.Specification, filter ProvisionalFilter) func(matter.Command, *raymond.Options) raymond.SafeString {

--- a/idl/entities.go
+++ b/idl/entities.go
@@ -54,8 +54,7 @@ func enumerateEntitiesHelper[T types.Entity](list []T, spec *spec.Specification,
 		df.Set("first", i == 0)
 		df.Set("last", i == len(list)-1)
 		if spec != nil {
-			refs, ok := spec.ClusterRefs.Get(en)
-			if ok && refs.Size() > 1 {
+			if isShared(spec, en) {
 				df.Set("shared", true)
 			}
 			df.Set("provisional", isProvisional(spec, en))
@@ -67,6 +66,56 @@ func enumerateEntitiesHelper[T types.Entity](list []T, spec *spec.Specification,
 		result.WriteString(options.FnCtxData(en, df))
 	}
 	return raymond.SafeString(result.String())
+}
+
+func isShared(spec *spec.Specification, en types.Entity) bool {
+	refs, ok := spec.ClusterRefs.Get(en)
+	if ok && refs.Size() > 1 {
+		return true
+	}
+	var cluster *matter.Cluster
+	var name string
+	var isTargetType bool
+	switch entity := any(en).(type) {
+	case *matter.Struct:
+		cluster = entity.Cluster()
+		name = entity.Name
+		isTargetType = true
+	case *matter.Enum:
+		cluster = entity.Cluster()
+		name = entity.Name
+		isTargetType = true
+	case *matter.Bitmap:
+		cluster = entity.Cluster()
+		name = entity.Name
+		isTargetType = true
+	}
+	if !isTargetType || cluster == nil {
+		return false
+	}
+	doc, ok := spec.DocRefs[cluster]
+	if !ok {
+		return false
+	}
+	if spec.Errata == nil {
+		return false
+	}
+	errata := spec.Errata.Get(doc.Path.Relative)
+	if errata == nil {
+		return false
+	}
+	switch any(en).(type) {
+	case *matter.Struct:
+		_, ok = errata.SDK.SharedStructs[name]
+		return ok
+	case *matter.Enum:
+		_, ok = errata.SDK.SharedEnums[name]
+		return ok
+	case *matter.Bitmap:
+		_, ok = errata.SDK.SharedBitmaps[name]
+		return ok
+	}
+	return false
 }
 
 func isProvisional(spec *spec.Specification, entity types.Entity) bool {

--- a/idl/entities.go
+++ b/idl/entities.go
@@ -138,6 +138,7 @@ func isProvisional(spec *spec.Specification, entity types.Entity) bool {
 		return false
 	}
 	is := provisional.Check(spec, entity, entity)
+
 	switch is {
 	case provisional.StateAllClustersProvisional,
 		provisional.StateAllDataTypeReferencesProvisional,

--- a/idl/entities.go
+++ b/idl/entities.go
@@ -321,7 +321,7 @@ func parseExistingMatterElements(path string) (map[string]bool, error) {
 					break
 				}
 			}
-		} else if strings.Contains(trimmed, " event ") {
+		} else if strings.Contains(trimmed, " event ") && !strings.Contains(trimmed, "attribute ") && !strings.Contains(trimmed, "command ") {
 			eqIdx := strings.Index(trimmed, "=")
 			if eqIdx != -1 {
 				left := strings.TrimSpace(trimmed[:eqIdx])

--- a/idl/entities.go
+++ b/idl/entities.go
@@ -121,7 +121,7 @@ func isShared(spec *spec.Specification, en types.Entity) bool {
 func isProvisional(spec *spec.Specification, entity types.Entity) bool {
 	switch entity := entity.(type) {
 	case *matter.Bitmap:
-		if entity.Name == "Feature" {
+		if entity.Name == "Feature" || entity.Name == "Features" {
 			return false
 		}
 	case *matter.Enum:
@@ -161,7 +161,14 @@ func entityPath(e types.Entity) string {
 			parts = append(parts, node.Name)
 			curr = node.Parent()
 		case *matter.Bitmap:
-			parts = append(parts, node.Name)
+			if node.Name == "Features" {
+				parts = append(parts, "Feature")
+			} else {
+				parts = append(parts, node.Name)
+			}
+			curr = node.Parent()
+		case *matter.Features:
+			parts = append(parts, "Feature")
 			curr = node.Parent()
 		case *matter.Struct:
 			parts = append(parts, node.Name)

--- a/idl/entities.go
+++ b/idl/entities.go
@@ -251,6 +251,17 @@ func parseExistingMatterElements(path string) (map[string]bool, error) {
 		if trimmed == "" || strings.HasPrefix(trimmed, "//") || strings.HasPrefix(trimmed, "/*") || strings.HasPrefix(trimmed, "*") {
 			continue
 		}
+		for {
+			accessIdx := strings.Index(trimmed, "access(")
+			if accessIdx == -1 {
+				break
+			}
+			closeIdx := strings.Index(trimmed[accessIdx:], ")")
+			if closeIdx == -1 {
+				break
+			}
+			trimmed = trimmed[:accessIdx] + " " + trimmed[accessIdx+closeIdx+1:]
+		}
 
 		if strings.HasPrefix(trimmed, "cluster ") || strings.Contains(trimmed, " cluster ") {
 			parts := strings.Fields(trimmed)

--- a/idl/entities.go
+++ b/idl/entities.go
@@ -76,7 +76,7 @@ func isShared(spec *spec.Specification, en types.Entity) bool {
 	var cluster *matter.Cluster
 	var name string
 	var isTargetType bool
-	switch entity := any(en).(type) {
+	switch entity := en.(type) {
 	case *matter.Struct:
 		cluster = entity.Cluster()
 		name = entity.Name
@@ -104,7 +104,7 @@ func isShared(spec *spec.Specification, en types.Entity) bool {
 	if errata == nil {
 		return false
 	}
-	switch any(en).(type) {
+	switch en.(type) {
 	case *matter.Struct:
 		_, ok = errata.SDK.SharedStructs[name]
 		return ok
@@ -264,11 +264,24 @@ func parseExistingMatterElements(path string) (map[string]bool, error) {
 			if accessIdx == -1 {
 				break
 			}
-			closeIdx := strings.Index(trimmed[accessIdx:], ")")
+			depth := 1
+			closeIdx := -1
+			startSearch := accessIdx + len("access(")
+			for i := startSearch; i < len(trimmed); i++ {
+				if trimmed[i] == '(' {
+					depth++
+				} else if trimmed[i] == ')' {
+					depth--
+					if depth == 0 {
+						closeIdx = i
+						break
+					}
+				}
+			}
 			if closeIdx == -1 {
 				break
 			}
-			trimmed = trimmed[:accessIdx] + " " + trimmed[accessIdx+closeIdx+1:]
+			trimmed = trimmed[:accessIdx] + " " + trimmed[closeIdx+1:]
 		}
 
 		if strings.HasPrefix(trimmed, "cluster ") || strings.Contains(trimmed, " cluster ") {

--- a/idl/entities.go
+++ b/idl/entities.go
@@ -254,15 +254,14 @@ func parseExistingMatterElements(path string) (map[string]bool, error) {
 				}
 			}
 		} else if strings.Contains(trimmed, " event ") {
-			parts := strings.Fields(trimmed)
-			for idx, word := range parts {
-				if word == "event" && idx+1 < len(parts) {
-					name := parts[idx+1]
-					name = strings.TrimSuffix(name, "{")
-					name = strings.Split(name, "=")[0]
+			eqIdx := strings.Index(trimmed, "=")
+			if eqIdx != -1 {
+				left := strings.TrimSpace(trimmed[:eqIdx])
+				parts := strings.Fields(left)
+				if len(parts) > 0 {
+					name := parts[len(parts)-1]
 					declName = strings.TrimSpace(name)
 					declType = "event"
-					break
 				}
 			}
 		} else if strings.Contains(trimmed, "attribute ") {

--- a/idl/entities_test.go
+++ b/idl/entities_test.go
@@ -51,6 +51,8 @@ cluster DoorLock = 257 {
   request command LockDoor() = 0;
   response command LockDoorResponse() = 1;
   command optional OptCommand() = 2;
+  timed command access(invoke: manage) UpdatePIN(UpdatePINRequest): DefaultSuccess = 3;
+  command access(invoke: administer) ResetPIN() = 4;
 }
 
 cluster BasicInformation = 40 {
@@ -94,6 +96,8 @@ cluster BasicInformation = 40 {
 		"doorlock.command.lockdoor":                            true,
 		"doorlock.command.lockdoorresponse":                    true,
 		"doorlock.command.optcommand":                          true,
+		"doorlock.command.updatepin":                           true,
+		"doorlock.command.resetpin":                            true,
 		"basicinformation":                                     true,
 		"basicinformation.producttypeenum":                     true,
 		"basicinformation.producttypeenum.item":                true,

--- a/idl/entities_test.go
+++ b/idl/entities_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
+
+	"github.com/project-chip/alchemy/matter"
 )
 
 func TestParseExistingMatterElements(t *testing.T) {
@@ -115,3 +117,39 @@ cluster BasicInformation = 40 {
 		}
 	}
 }
+
+func TestEntityPath(t *testing.T) {
+	cluster := &matter.Cluster{
+		Name: "DoorLock",
+	}
+	features := matter.NewFeatures(nil, cluster)
+	featureBit := matter.NewFeature(nil, "0", "PinGeneration", "PIN", "Supports PINs", nil)
+	features.AddFeatureBit(featureBit)
+
+	t.Run("Features", func(t *testing.T) {
+		got := entityPath(features)
+		want := "DoorLock.Feature"
+		if got != want {
+			t.Errorf("entityPath(features) = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("FeatureBit", func(t *testing.T) {
+		got := entityPath(featureBit)
+		want := "DoorLock.Feature.PinGeneration"
+		if got != want {
+			t.Errorf("entityPath(featureBit) = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("IsElementPresent", func(t *testing.T) {
+		existing := map[string]bool{
+			"doorlock.feature.pingeneration": true,
+		}
+		got := isElementPresent(existing, featureBit)
+		if !got {
+			t.Errorf("isElementPresent() = false, want true")
+		}
+	})
+}
+

--- a/idl/entities_test.go
+++ b/idl/entities_test.go
@@ -41,11 +41,16 @@ cluster DoorLock = 257 {
     int32u eventId = 1;
   }
 
+  info event optional opt_event = 2 {
+    int32u someField = 0;
+  }
+
   readonly attribute DoorStateEnum doorState = 0;
   attribute int32u pinCodeLength = 1;
 
   request command LockDoor() = 0;
   response command LockDoorResponse() = 1;
+  command optional OptCommand() = 2;
 }
 
 cluster BasicInformation = 40 {
@@ -82,10 +87,13 @@ cluster BasicInformation = 40 {
 		"doorlock.event.event_id":                              true,
 		"doorlock.event.event_id.attributeid":                  true,
 		"doorlock.event.event_id.eventid":                      true,
+		"doorlock.event.opt_event":                             true,
+		"doorlock.event.opt_event.somefield":                   true,
 		"doorlock.attribute.doorstate":                         true,
 		"doorlock.attribute.pincodelength":                     true,
 		"doorlock.command.lockdoor":                            true,
 		"doorlock.command.lockdoorresponse":                    true,
+		"doorlock.command.optcommand":                          true,
 		"basicinformation":                                     true,
 		"basicinformation.producttypeenum":                     true,
 		"basicinformation.producttypeenum.item":                true,

--- a/idl/helper.go
+++ b/idl/helper.go
@@ -124,7 +124,7 @@ func maxValue(field matter.Field, fs matter.FieldSet) (max types.DataTypeExtreme
 	}
 	if !field.Type.HasLength() {
 		switch field.Type.Entity.(type) {
-		case *matter.Enum, *matter.Bitmap:
+		case *matter.Enum, *matter.Bitmap, *matter.Struct:
 			return
 		}
 		if field.Type.BaseType.IsSimple() {

--- a/idl/render.go
+++ b/idl/render.go
@@ -255,18 +255,22 @@ func (p IdlRenderer) Process(cxt context.Context, input *pipeline.Data[*File], i
 		if !ok {
 			continue
 		}
+		ceNames := make(map[string]struct{}, len(ce))
+		for e := range ce {
+			ceNames[matter.EntityName(e)] = struct{}{}
+		}
 		for _, s := range clusterInfo.Cluster.Structs {
-			if hasEntityWithName(ce, s.Name) {
+			if _, ok := ceNames[s.Name]; ok {
 				clusterInfo.ReferencedStructs = append(clusterInfo.ReferencedStructs, s)
 			}
 		}
 		for _, en := range clusterInfo.Cluster.Enums {
-			if hasEntityWithName(ce, en.Name) {
+			if _, ok := ceNames[en.Name]; ok {
 				clusterInfo.ReferencedEnums = append(clusterInfo.ReferencedEnums, en)
 			}
 		}
 		for _, bm := range clusterInfo.Cluster.Bitmaps {
-			if hasEntityWithName(ce, bm.Name) {
+			if _, ok := ceNames[bm.Name]; ok {
 				clusterInfo.ReferencedBitmaps = append(clusterInfo.ReferencedBitmaps, bm)
 			}
 		}
@@ -357,11 +361,4 @@ func forceIncludeEntity(spec *spec.Specification, cluster *matter.Cluster, e typ
 	return false
 }
 
-func hasEntityWithName(ce map[types.Entity]struct{}, name string) bool {
-	for e := range ce {
-		if matter.EntityName(e) == name {
-			return true
-		}
-	}
-	return false
-}
+

--- a/idl/render.go
+++ b/idl/render.go
@@ -256,17 +256,17 @@ func (p IdlRenderer) Process(cxt context.Context, input *pipeline.Data[*File], i
 			continue
 		}
 		for _, s := range clusterInfo.Cluster.Structs {
-			if _, ok := ce[s]; ok {
+			if hasEntityWithName(ce, s.Name) {
 				clusterInfo.ReferencedStructs = append(clusterInfo.ReferencedStructs, s)
 			}
 		}
 		for _, en := range clusterInfo.Cluster.Enums {
-			if _, ok := ce[en]; ok {
+			if hasEntityWithName(ce, en.Name) {
 				clusterInfo.ReferencedEnums = append(clusterInfo.ReferencedEnums, en)
 			}
 		}
 		for _, bm := range clusterInfo.Cluster.Bitmaps {
-			if _, ok := ce[bm]; ok {
+			if hasEntityWithName(ce, bm.Name) {
 				clusterInfo.ReferencedBitmaps = append(clusterInfo.ReferencedBitmaps, bm)
 			}
 		}
@@ -351,6 +351,15 @@ func forceIncludeEntity(spec *spec.Specification, cluster *matter.Cluster, e typ
 		}
 	case *matter.Struct:
 		if _, ok := errata.SDK.ExtraTypes.Structs[e.Name]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func hasEntityWithName(ce map[types.Entity]struct{}, name string) bool {
+	for e := range ce {
+		if matter.EntityName(e) == name {
 			return true
 		}
 	}

--- a/idl/render_test.go
+++ b/idl/render_test.go
@@ -346,7 +346,7 @@ func TestSuppressProvisionalIntegration(t *testing.T) {
 	if !strings.Contains(contentNone, "struct ProvCmd") || !strings.Contains(contentNone, "struct NonProvCmd") {
 		t.Errorf("expected commands in none output: %s", contentNone)
 	}
-	if !strings.Contains(contentNone, "event optional ProvEvt") || !strings.Contains(contentNone, "event NonProvEvt") {
+	if !strings.Contains(contentNone, "optional event ProvEvt") || !strings.Contains(contentNone, "event NonProvEvt") {
 		t.Errorf("expected events in none output: %s", contentNone)
 	}
 
@@ -378,7 +378,7 @@ func TestSuppressProvisionalIntegration(t *testing.T) {
 	if strings.Contains(contentAll, "struct ProvCmd") || !strings.Contains(contentAll, "struct NonProvCmd") {
 		t.Errorf("expected commands in all output (ProvCmd suppressed, NonProvCmd kept): %s", contentAll)
 	}
-	if strings.Contains(contentAll, "event optional ProvEvt") || !strings.Contains(contentAll, "event NonProvEvt") {
+	if strings.Contains(contentAll, "optional event ProvEvt") || !strings.Contains(contentAll, "event NonProvEvt") {
 		t.Errorf("expected events in all output (ProvEvt suppressed, NonProvEvt kept): %s", contentAll)
 	}
 
@@ -442,7 +442,7 @@ provisional cluster ProvCluster = 2 {
 		t.Errorf("expected commands in keep output: %s", contentKeep)
 	}
 	// ProvEvt was NOT in existing file, so it MUST be suppressed!
-	if strings.Contains(contentKeep, "optional ProvEvt") {
+	if strings.Contains(contentKeep, "optional event ProvEvt") {
 		t.Errorf("expected ProvEvt to be suppressed in keep output: %s", contentKeep)
 	}
 	if !strings.Contains(contentKeep, "event NonProvEvt") {

--- a/idl/render_test.go
+++ b/idl/render_test.go
@@ -320,7 +320,7 @@ func TestSuppressProvisionalIntegration(t *testing.T) {
 	if !strings.Contains(contentNone, "struct ProvCmd") || !strings.Contains(contentNone, "struct NonProvCmd") {
 		t.Errorf("expected commands in none output: %s", contentNone)
 	}
-	if !strings.Contains(contentNone, "event ProvEvt") || !strings.Contains(contentNone, "event NonProvEvt") {
+	if !strings.Contains(contentNone, "event optional ProvEvt") || !strings.Contains(contentNone, "event NonProvEvt") {
 		t.Errorf("expected events in none output: %s", contentNone)
 	}
 
@@ -352,7 +352,7 @@ func TestSuppressProvisionalIntegration(t *testing.T) {
 	if strings.Contains(contentAll, "struct ProvCmd") || !strings.Contains(contentAll, "struct NonProvCmd") {
 		t.Errorf("expected commands in all output (ProvCmd suppressed, NonProvCmd kept): %s", contentAll)
 	}
-	if strings.Contains(contentAll, "event ProvEvt") || !strings.Contains(contentAll, "event NonProvEvt") {
+	if strings.Contains(contentAll, "event optional ProvEvt") || !strings.Contains(contentAll, "event NonProvEvt") {
 		t.Errorf("expected events in all output (ProvEvt suppressed, NonProvEvt kept): %s", contentAll)
 	}
 
@@ -414,7 +414,7 @@ cluster MyCluster = 1 {
 		t.Errorf("expected commands in keep output: %s", contentKeep)
 	}
 	// ProvEvt was NOT in existing file, so it MUST be suppressed!
-	if strings.Contains(contentKeep, "event ProvEvt") {
+	if strings.Contains(contentKeep, "optional ProvEvt") {
 		t.Errorf("expected ProvEvt to be suppressed in keep output: %s", contentKeep)
 	}
 	if !strings.Contains(contentKeep, "event NonProvEvt") {

--- a/idl/render_test.go
+++ b/idl/render_test.go
@@ -92,6 +92,22 @@ func TestSuppressProvisionalIntegration(t *testing.T) {
 	specification.ClustersByID[1] = cluster
 	specification.ClustersByName["MyCluster"] = cluster
 
+	provCluster := matter.NewCluster(nil)
+	provCluster.Name = "ProvCluster"
+	provCluster.ID = matter.NewNumber(2)
+	provCluster.Conformance = conformance.Set{&conformance.Provisional{}}
+
+	specification.ClustersByID[2] = provCluster
+	specification.ClustersByName["ProvCluster"] = provCluster
+
+	provCluster2 := matter.NewCluster(nil)
+	provCluster2.Name = "ProvCluster2"
+	provCluster2.ID = matter.NewNumber(3)
+	provCluster2.Conformance = conformance.Set{&conformance.Provisional{}}
+
+	specification.ClustersByID[3] = provCluster2
+	specification.ClustersByName["ProvCluster2"] = provCluster2
+
 	// Enums
 	provEnum := &matter.Enum{Name: "ProvEnum", Type: types.NewDataType(types.BaseDataTypeEnum8, types.DataTypeRankScalar)}
 	provEnum.SetParent(cluster)
@@ -275,6 +291,16 @@ func TestSuppressProvisionalIntegration(t *testing.T) {
 						Name: "MyCluster",
 						Side: "server",
 					},
+					{
+						Code: 2,
+						Name: "ProvCluster",
+						Side: "server",
+					},
+					{
+						Code: 3,
+						Name: "ProvCluster2",
+						Side: "server",
+					},
 				},
 			},
 		},
@@ -377,6 +403,8 @@ cluster MyCluster = 1 {
   provisional readonly attribute ProvBitmap provAttrBitmap = 3;
   provisional command ProvCmd() = 1;
 }
+provisional cluster ProvCluster = 2 {
+}
 `
 	existingPath := filepath.Join(tmpDir, "existing.matter")
 	err = os.WriteFile(existingPath, []byte(existingFileContent), 0644)
@@ -419,5 +447,13 @@ cluster MyCluster = 1 {
 	}
 	if !strings.Contains(contentKeep, "event NonProvEvt") {
 		t.Errorf("expected NonProvEvt to be kept in keep output: %s", contentKeep)
+	}
+	// ProvCluster was in existing file, so it MUST be kept!
+	if !strings.Contains(contentKeep, "cluster ProvCluster") {
+		t.Errorf("expected ProvCluster to be kept in keep output: %s", contentKeep)
+	}
+	// ProvCluster2 was NOT in existing file, so it MUST be suppressed!
+	if strings.Contains(contentKeep, "cluster ProvCluster2") {
+		t.Errorf("expected ProvCluster2 to be suppressed in keep output: %s", contentKeep)
 	}
 }

--- a/idl/templates/command.handlebars
+++ b/idl/templates/command.handlebars
@@ -2,4 +2,4 @@
 {{#if provisional}}provisional {{/if ~}}
 {{#ifFabricScoped command.Access.FabricScoping}}fabric {{/ifFabricScoped ~}}
 {{#isTimed command}}timed {{/isTimed ~}}
-command {{> access access=command.Access ~}}{{asUpperCamelCase command.Name}}({{#ifHasValidFields command.Fields}}{{requestName command}}Request{{/ifHasValidFields}}): {{responseName command}} = {{number command.ID}};
+command {{> access access=command.Access ~}}{{#ifOptional command.Conformance}}optional {{/ifOptional ~}}{{asUpperCamelCase command.Name}}({{#ifHasValidFields command.Fields}}{{requestName command}}Request{{/ifHasValidFields}}): {{responseName command}} = {{number command.ID}};

--- a/idl/templates/command.handlebars
+++ b/idl/templates/command.handlebars
@@ -2,4 +2,4 @@
 {{#if provisional}}provisional {{/if ~}}
 {{#ifFabricScoped command.Access.FabricScoping}}fabric {{/ifFabricScoped ~}}
 {{#isTimed command}}timed {{/isTimed ~}}
-command {{> access access=command.Access ~}}{{#ifOptional command.Conformance}}optional {{/ifOptional ~}}{{asUpperCamelCase command.Name}}({{#ifHasValidFields command.Fields}}{{requestName command}}Request{{/ifHasValidFields}}): {{responseName command}} = {{number command.ID}};
+{{#ifOptional command.Conformance}}optional {{/ifOptional ~}}command {{> access access=command.Access ~}}{{asUpperCamelCase command.Name}}({{#ifHasValidFields command.Fields}}{{requestName command}}Request{{/ifHasValidFields}}): {{responseName command}} = {{number command.ID}};

--- a/idl/templates/event.handlebars
+++ b/idl/templates/event.handlebars
@@ -1,6 +1,6 @@
 {{#if provisional}}provisional {{/if ~}}
 {{#ifFabricSensitive event.Access}}fabric_sensitive {{/ifFabricSensitive ~}}
-{{toLower event.Priority}} event {{> access access=event.Access ~}}{{#ifOptional event.Conformance}}optional {{/ifOptional ~}}{{asUpperCamelCase event.Name}} = {{number event.ID}} {
+{{toLower event.Priority}} {{#ifOptional event.Conformance}}optional {{/ifOptional ~}}event {{> access access=event.Access ~}}{{asUpperCamelCase event.Name}} = {{number event.ID}} {
 {{#eventFields event}}
   {{> field cluster=cluster event=event field=this fieldset=event.Fields}}
 {{/eventFields}}

--- a/idl/templates/event.handlebars
+++ b/idl/templates/event.handlebars
@@ -1,6 +1,6 @@
 {{#if provisional}}provisional {{/if ~}}
 {{#ifFabricSensitive event.Access}}fabric_sensitive {{/ifFabricSensitive ~}}
-{{toLower event.Priority}} event {{> access access=event.Access ~}}{{asUpperCamelCase event.Name}} = {{number event.ID}} {
+{{toLower event.Priority}} event {{> access access=event.Access ~}}{{#ifOptional event.Conformance}}optional {{/ifOptional ~}}{{asUpperCamelCase event.Name}} = {{number event.ID}} {
 {{#eventFields event}}
   {{> field cluster=cluster event=event field=this fieldset=event.Fields}}
 {{/eventFields}}

--- a/matter/bitmap.go
+++ b/matter/bitmap.go
@@ -85,7 +85,7 @@ func (bm *Bitmap) CloneTo(parent types.Entity) *Bitmap {
 		nbm.Type = bm.Type.Clone()
 	}
 	for _, b := range bm.Bits {
-		nbm.Bits = append(nbm.Bits, b.CloneTo(parent))
+		nbm.Bits = append(nbm.Bits, b.CloneTo(nbm))
 	}
 	return nbm
 }

--- a/matter/spec/conformance.go
+++ b/matter/spec/conformance.go
@@ -11,7 +11,11 @@ import (
 )
 
 func (spec *Specification) ResolveConformances() {
-	sp := &Builder{Spec: spec}
+	sp := &Builder{
+		Spec:                spec,
+		conformanceFailures: make(map[any]referenceFailure),
+		constraintFailures:  make(map[any]referenceFailure),
+	}
 	sp.ResolveConformances()
 }
 

--- a/matter/spec/datatypes.go
+++ b/matter/spec/datatypes.go
@@ -274,3 +274,9 @@ func (sp *Builder) getCustomDataTypeFromFieldReference(library *Library, cluster
 	}
 	return
 }
+
+func (spec *Specification) ResolveDataTypeReferences() {
+	builder := &Builder{Spec: spec}
+	builder.resolveClusterDataTypeReferences(true)
+	builder.resolveClusterDataTypeReferences(false)
+}

--- a/matter/spec/datatypes.go
+++ b/matter/spec/datatypes.go
@@ -160,7 +160,19 @@ func (sp *Builder) resolveFieldDataTypes(library *Library, cluster *matter.Clust
 		return
 	}
 	if dataType.Entity != nil {
-		// This has already been resolved by some other process
+		if cluster != nil && cluster.Hierarchy != "Base" {
+			// If this is a derived cluster and the entity reference was already resolved to a base
+			// cluster entity (e.g., during base struct/command inheritance cloning), we attempt to
+			// redirect it to the local cloned copy in the derived cluster. Otherwise, the local cloned
+			// entity will have 0 references and will be omitted from the generated IDL.
+			parentCluster, hasParentCluster := dataType.Entity.Parent().(*matter.Cluster)
+			if hasParentCluster && parentCluster != cluster {
+				local := finder.findEntityByIdentifier(matter.EntityName(dataType.Entity), field)
+				if local != nil {
+					dataType.Entity = local
+				}
+			}
+		}
 		if cluster != nil {
 			sp.Spec.addEntity(dataType.Entity, cluster)
 		}

--- a/matter/spec/datatypes.go
+++ b/matter/spec/datatypes.go
@@ -170,6 +170,9 @@ func (sp *Builder) resolveFieldDataTypes(library *Library, cluster *matter.Clust
 				local := finder.findEntityByIdentifier(matter.EntityName(dataType.Entity), field)
 				if local != nil {
 					dataType.Entity = local
+				} else {
+					slog.Error("failed to find local cloned entity for data type reference", slog.String("name", matter.EntityName(dataType.Entity)), slog.String("field", field.Name), slog.String("cluster", cluster.Name))
+					sp.Spec.addError(&MissingClonedEntityError{Entity: dataType.Entity, Field: field})
 				}
 			}
 		}

--- a/matter/spec/datatypes.go
+++ b/matter/spec/datatypes.go
@@ -231,9 +231,6 @@ func (sp *Builder) resolveCommandResponseDataType(library *Library, cluster *mat
 	}
 	for _, cmd := range cluster.Commands {
 		if cmd.Direction == desiredDirection && cmd.Name == command.Response.Name {
-			if cmd.Response == nil {
-				break
-			}
 			command.Response.Entity = cmd
 			return
 		}

--- a/matter/spec/error.go
+++ b/matter/spec/error.go
@@ -777,3 +777,20 @@ func (ccme ConformanceChoiceMismatchError) Error() string {
 
 	return fmt.Sprintf("mismatch in choice limit \"%s\": %s vs. %s", ccme.Set, limit, previous)
 }
+
+type MissingClonedEntityError struct {
+	Entity types.Entity
+	Field  *matter.Field
+}
+
+func (mcee *MissingClonedEntityError) Type() ErrorType {
+	return ErrorTypeUnknown
+}
+
+func (mcee *MissingClonedEntityError) Origin() (path string, line int) {
+	return mcee.Field.Origin()
+}
+
+func (mcee *MissingClonedEntityError) Error() string {
+	return fmt.Sprintf("failed to find local clone of entity %s for field %s", matter.EntityName(mcee.Entity), mcee.Field.Name)
+}

--- a/matter/spec/patch.go
+++ b/matter/spec/patch.go
@@ -115,11 +115,16 @@ func patchContentLaunchCluster(spec *Specification) {
 func patchLabelCluster(spec *Specification) {
 	/*
 		Another hacky workaround: the spec defines LabelStruct under a base cluster called Label Cluster, but the
-		ZAP XML has this struct under Fixed Label
+		ZAP XML has this struct under Fixed Label and User Label
 	*/
 	fixedLabelCluster, ok := spec.ClustersByName["Fixed Label"]
 	if !ok {
 		slog.Warn("Could not find Fixed Label cluster")
+		return
+	}
+	userLabelCluster, ok := spec.ClustersByName["User Label"]
+	if !ok {
+		slog.Warn("Could not find User Label cluster")
 		return
 	}
 	labelCluster, ok := spec.ClustersByName["Label"]
@@ -131,6 +136,31 @@ func patchLabelCluster(spec *Specification) {
 		if s.Name == "LabelStruct" {
 			fixedLabelCluster.MoveStruct(s)
 			spec.DataTypeRefs.Add(fixedLabelCluster, s)
+
+			clone := s.Clone()
+			userLabelCluster.MoveStruct(clone)
+			spec.DataTypeRefs.Add(userLabelCluster, clone)
+
+			userLabelCluster.TraverseDataTypes(func(parent, entity types.Entity) parse.SearchShould {
+				if entity == s {
+					switch parent := parent.(type) {
+					case *matter.Field:
+						fieldType := parent.Type
+						if fieldType == nil {
+							return parse.SearchShouldContinue
+						}
+						if fieldType.IsArray() {
+							fieldType = fieldType.EntryType
+						}
+						if fieldType == nil {
+							return parse.SearchShouldContinue
+						}
+						fieldType.Entity = clone
+					}
+				}
+				return parse.SearchShouldContinue
+			})
+
 			labelCluster.Structs = slices.Delete(labelCluster.Structs, i, i+1)
 			break
 		}

--- a/matter/types/data.go
+++ b/matter/types/data.go
@@ -255,7 +255,7 @@ func ParseDataTypeName(typeName string) (baseType BaseDataType, name string) {
 }
 
 func (dt *DataType) Clone() *DataType {
-	ndt := &DataType{Name: dt.Name, BaseType: dt.BaseType, Source: dt.Source}
+	ndt := &DataType{Name: dt.Name, BaseType: dt.BaseType, Entity: dt.Entity, Source: dt.Source}
 	if dt.EntryType != nil {
 		ndt.EntryType = dt.EntryType.Clone()
 	}

--- a/matter/types/data.go
+++ b/matter/types/data.go
@@ -71,38 +71,38 @@ func ParseDataTypeName(typeName string) (baseType BaseDataType, name string) {
 	switch strings.ToLower(typeName) {
 	case "bool", "boolean":
 		baseType = BaseDataTypeBoolean
-	case "uint8":
+	case "uint8", "int8u":
 		baseType = BaseDataTypeUInt8
-	case "uint16":
+	case "uint16", "int16u":
 		baseType = BaseDataTypeUInt16
-	case "uint24":
+	case "uint24", "int24u":
 		baseType = BaseDataTypeUInt24
-	case "uint32":
+	case "uint32", "int32u":
 		baseType = BaseDataTypeUInt32
-	case "uint40":
+	case "uint40", "int40u":
 		baseType = BaseDataTypeUInt40
-	case "uint48":
+	case "uint48", "int48u":
 		baseType = BaseDataTypeUInt48
-	case "uint56":
+	case "uint56", "int56u":
 		baseType = BaseDataTypeUInt56
-	case "uint64":
+	case "uint64", "int64u":
 		baseType = BaseDataTypeUInt64
 
-	case "int8":
+	case "int8", "int8s":
 		baseType = BaseDataTypeInt8
-	case "int16":
+	case "int16", "int16s":
 		baseType = BaseDataTypeInt16
-	case "int24":
+	case "int24", "int24s":
 		baseType = BaseDataTypeInt24
-	case "int32":
+	case "int32", "int32s":
 		baseType = BaseDataTypeInt32
-	case "int40":
+	case "int40", "int40s":
 		baseType = BaseDataTypeInt40
-	case "int48":
+	case "int48", "int48s":
 		baseType = BaseDataTypeInt48
-	case "int56":
+	case "int56", "int56s":
 		baseType = BaseDataTypeInt56
-	case "int64":
+	case "int64", "int64s":
 		baseType = BaseDataTypeInt64
 
 	case "single":
@@ -115,17 +115,17 @@ func ParseDataTypeName(typeName string) (baseType BaseDataType, name string) {
 	case "enum16":
 		baseType = BaseDataTypeEnum16
 
-	case "map8":
+	case "map8", "bitmap8":
 		baseType = BaseDataTypeMap8
-	case "map16":
+	case "map16", "bitmap16":
 		baseType = BaseDataTypeMap16
-	case "map32":
+	case "map32", "bitmap32":
 		baseType = BaseDataTypeMap32
-	case "map64":
+	case "map64", "bitmap64":
 		baseType = BaseDataTypeMap64
-	case "string", "character string":
+	case "string", "character string", "char_string":
 		baseType = BaseDataTypeString
-	case "octstr", "octet string":
+	case "octstr", "octet string", "octet_string":
 		baseType = BaseDataTypeOctStr
 	case "percent":
 		baseType = BaseDataTypePercent

--- a/provisional/state.go
+++ b/provisional/state.go
@@ -90,7 +90,7 @@ func Check(spec *spec.Specification, entity types.Entity, originalEntity types.E
 	case *matter.Enum, *matter.Bitmap, *matter.Struct:
 		refs, ok := spec.DataTypeRefs.Get(entity)
 		if !ok || refs.Size() == 0 {
-			if e, ok := entity.(*matter.Bitmap); ok && e.Name == "Features" {
+			if e, ok := entity.(*matter.Bitmap); ok && (e.Name == "Features" || e.Name == "Feature") {
 				if parentCluster, ok := entity.Parent().(*matter.Cluster); ok {
 					return Check(spec, parentCluster.Features, originalEntity)
 				}

--- a/sdk/cluster.go
+++ b/sdk/cluster.go
@@ -11,7 +11,7 @@ import (
 	"github.com/project-chip/alchemy/matter/types"
 )
 
-func applyErrataToCluster(spec *spec.Specification, cluster *matter.Cluster, errata errata.SDK) {
+func applyErrataToCluster(spec *spec.Specification, cluster *matter.Cluster, errata errata.SDK, options applyErrataOptions) {
 	if errata.Types != nil {
 		ac, ok := errata.Types.Clusters[cluster.Name]
 		if ok {
@@ -53,27 +53,54 @@ func applyErrataToCluster(spec *spec.Specification, cluster *matter.Cluster, err
 		applyErrataToEvent(ev, errata.TypeNames, errata.Types)
 	}
 
-	sharedEntities := make(map[types.Entity]types.Entity)
-	for bitmapName := range errata.SharedBitmaps {
-		if cluster.ParentCluster == nil {
-			slog.Warn("Errata: separate bitmap on cluster without parent", slog.String("bitmapName", bitmapName), slog.String("clusterName", cluster.Name))
-			continue
+	if !options.skipSharedEntities {
+		sharedEntities := make(map[types.Entity]types.Entity)
+		for bitmapName := range errata.SharedBitmaps {
+			if cluster.ParentCluster == nil {
+				slog.Warn("Errata: separate bitmap on cluster without parent", slog.String("bitmapName", bitmapName), slog.String("clusterName", cluster.Name))
+				continue
+			}
+			cluster.Bitmaps = replaceSharedEntity(spec, cluster, cluster.ParentCluster, bitmapName, cluster.ParentCluster.Bitmaps, cluster.Bitmaps, sharedEntities)
 		}
-		cluster.Bitmaps = replaceSharedEntity(spec, cluster, cluster.ParentCluster, bitmapName, cluster.ParentCluster.Bitmaps, cluster.Bitmaps, sharedEntities)
-	}
-	for enumName := range errata.SharedEnums {
-		if cluster.ParentCluster == nil {
-			slog.Warn("Errata: separate enum on cluster without parent", slog.String("enumName", enumName), slog.String("clusterName", cluster.Name))
-			continue
+		for enumName := range errata.SharedEnums {
+			if cluster.ParentCluster == nil {
+				slog.Warn("Errata: separate enum on cluster without parent", slog.String("enumName", enumName), slog.String("clusterName", cluster.Name))
+				continue
+			}
+			cluster.Enums = replaceSharedEntity(spec, cluster, cluster.ParentCluster, enumName, cluster.ParentCluster.Enums, cluster.Enums, sharedEntities)
 		}
-		cluster.Enums = replaceSharedEntity(spec, cluster, cluster.ParentCluster, enumName, cluster.ParentCluster.Enums, cluster.Enums, sharedEntities)
-	}
-	for structName := range errata.SharedStructs {
-		if cluster.ParentCluster == nil {
-			slog.Warn("Errata: separate struct on cluster without parent", slog.String("structName", structName), slog.String("clusterName", cluster.Name))
-			continue
+		for structName := range errata.SharedStructs {
+			if cluster.ParentCluster == nil {
+				slog.Warn("Errata: separate struct on cluster without parent", slog.String("structName", structName), slog.String("clusterName", cluster.Name))
+				continue
+			}
+			cluster.Structs = replaceSharedEntity(spec, cluster, cluster.ParentCluster, structName, cluster.ParentCluster.Structs, cluster.Structs, sharedEntities)
 		}
-		cluster.Structs = replaceSharedEntity(spec, cluster, cluster.ParentCluster, structName, cluster.ParentCluster.Structs, cluster.Structs, sharedEntities)
+		if len(sharedEntities) > 0 {
+			cluster.TraverseDataTypes(func(parent, entity types.Entity) parse.SearchShould {
+				target, ok := sharedEntities[entity]
+				if !ok {
+					return parse.SearchShouldContinue
+				}
+				switch parent := parent.(type) {
+				case *matter.Field:
+					fieldType := parent.Type
+					if fieldType == nil {
+						break
+					}
+					if fieldType.IsArray() {
+						fieldType = fieldType.EntryType
+					}
+					if fieldType == nil {
+						break
+					}
+					fieldType.Entity = target
+
+				}
+				return parse.SearchShouldContinue
+			})
+
+		}
 	}
 	for enumName := range errata.SeparateEnums {
 		for _, en := range cluster.Enums {
@@ -81,31 +108,6 @@ func applyErrataToCluster(spec *spec.Specification, cluster *matter.Cluster, err
 				spec.ClusterRefs.Add(cluster, en)
 			}
 		}
-	}
-	if len(sharedEntities) > 0 {
-		cluster.TraverseDataTypes(func(parent, entity types.Entity) parse.SearchShould {
-			target, ok := sharedEntities[entity]
-			if !ok {
-				return parse.SearchShouldContinue
-			}
-			switch parent := parent.(type) {
-			case *matter.Field:
-				fieldType := parent.Type
-				if fieldType == nil {
-					break
-				}
-				if fieldType.IsArray() {
-					fieldType = fieldType.EntryType
-				}
-				if fieldType == nil {
-					break
-				}
-				fieldType.Entity = target
-
-			}
-			return parse.SearchShouldContinue
-		})
-
 	}
 
 }

--- a/sdk/cluster.go
+++ b/sdk/cluster.go
@@ -12,7 +12,7 @@ import (
 	"github.com/project-chip/alchemy/matter/types"
 )
 
-func applyErrataToCluster(spec *spec.Specification, cluster *matter.Cluster, errata errata.SDK, options applyErrataOptions) {
+func applyErrataToCluster(spec *spec.Specification, cluster *matter.Cluster, errata errata.SDK, options applyErrataOptions) error {
 	if errata.Types != nil {
 		ac, ok := errata.Types.Clusters[cluster.Name]
 		if ok {
@@ -31,7 +31,10 @@ func applyErrataToCluster(spec *spec.Specification, cluster *matter.Cluster, err
 			if !ok {
 				continue
 			}
-			applyErrataToField(a, ao)
+			err := applyErrataToField(a, ao)
+			if err != nil {
+				return err
+			}
 		}
 		if cluster.Features != nil {
 			fc, ok := errata.Types.Bitmaps["Features"]
@@ -48,13 +51,22 @@ func applyErrataToCluster(spec *spec.Specification, cluster *matter.Cluster, err
 		applyErrataToEnum(en, errata.TypeNames, errata.Types)
 	}
 	for _, s := range cluster.Structs {
-		applyErrataToStruct(s, errata.TypeNames, errata.Types)
+		err := applyErrataToStruct(s, errata.TypeNames, errata.Types)
+		if err != nil {
+			return err
+		}
 	}
 	for _, cmd := range cluster.Commands {
-		applyErrataToCommand(cmd, errata.TypeNames, errata.Types)
+		err := applyErrataToCommand(cmd, errata.TypeNames, errata.Types)
+		if err != nil {
+			return err
+		}
 	}
 	for _, ev := range cluster.Events {
-		applyErrataToEvent(ev, errata.TypeNames, errata.Types)
+		err := applyErrataToEvent(ev, errata.TypeNames, errata.Types)
+		if err != nil {
+			return err
+		}
 	}
 
 	if !options.skipSharedEntities {
@@ -114,6 +126,7 @@ func applyErrataToCluster(spec *spec.Specification, cluster *matter.Cluster, err
 		}
 	}
 
+	return nil
 }
 
 func replaceSharedEntity[T types.Entity](spec *spec.Specification, cluster *matter.Cluster, parentCluster *matter.Cluster, entityName string, parentList []T, targetList []T, sharedEntities map[types.Entity]types.Entity) []T {

--- a/sdk/cluster.go
+++ b/sdk/cluster.go
@@ -7,6 +7,7 @@ import (
 	"github.com/project-chip/alchemy/asciidoc/parse"
 	"github.com/project-chip/alchemy/errata"
 	"github.com/project-chip/alchemy/matter"
+	"github.com/project-chip/alchemy/matter/conformance"
 	"github.com/project-chip/alchemy/matter/spec"
 	"github.com/project-chip/alchemy/matter/types"
 )
@@ -20,6 +21,9 @@ func applyErrataToCluster(spec *spec.Specification, cluster *matter.Cluster, err
 			}
 			if ac.Description != "" {
 				cluster.Description = ac.Description
+			}
+			if ac.Conformance != "" {
+				cluster.Conformance = conformance.ParseConformance(ac.Conformance)
 			}
 		}
 		for _, a := range cluster.Attributes {

--- a/sdk/errata.go
+++ b/sdk/errata.go
@@ -89,6 +89,26 @@ func applyErrataToCommand(st *matter.Command, typeNames map[string]string, typeO
 		}
 		if override.Response != "" {
 			st.Response = types.ParseDataType(override.Response, types.DataTypeRankScalar)
+			// Since ApplyErrata runs after type resolution, we must manually resolve the response name
+			// to its command entity so that IDL and other templates can reference it properly.
+			if cluster, ok := st.Parent().(*matter.Cluster); ok {
+				var desiredDirection matter.Interface
+				switch st.Direction {
+				case matter.InterfaceServer:
+					desiredDirection = matter.InterfaceClient
+				case matter.InterfaceClient:
+					desiredDirection = matter.InterfaceServer
+				}
+				for _, cmd := range cluster.Commands {
+					if cmd.Direction == desiredDirection && cmd.Name == override.Response {
+						st.Response.Entity = cmd
+						break
+					}
+				}
+				if st.Response.Entity == nil {
+					slog.Warn("Failed to resolve overridden response", slog.String("command", st.Name), slog.String("response", override.Response))
+				}
+			}
 		}
 		applyErrataToFields(st.Fields, override)
 	}

--- a/sdk/errata.go
+++ b/sdk/errata.go
@@ -65,6 +65,7 @@ func ApplyErrata(spec *spec.Specification, opts ...ApplyErrataOption) (err error
 		}
 	}
 	if addedExtraEntities {
+		spec.ResolveDataTypeReferences()
 		spec.BuildDataTypeReferences()
 		spec.BuildClusterReferences()
 	}
@@ -111,6 +112,28 @@ func applyErrataToCommand(st *matter.Command, typeNames map[string]string, typeO
 			}
 		}
 		applyErrataToFields(st.Fields, override)
+		for _, f := range override.ExtraFields {
+			var found bool
+			for _, field := range st.Fields {
+				if field.Name == f.Name {
+					found = true
+					break
+				}
+			}
+			if !found {
+				field := matter.NewField(nil, st, types.EntityTypeCommandField)
+				field.Name = f.Name
+				if f.Type != "" {
+					var rank types.DataTypeRank = types.DataTypeRankScalar
+					if f.List {
+						rank = types.DataTypeRankList
+					}
+					field.Type = types.ParseDataType(f.Type, rank)
+				}
+				applyErrataToField(field, f)
+				st.Fields = append(st.Fields, field)
+			}
+		}
 	}
 	st.Name = applyTypeName(typeNames, st.Name)
 }
@@ -146,6 +169,28 @@ func applyErrataToEvent(ev *matter.Event, typeNames map[string]string, typeOverr
 			ev.Access.FabricSensitivity = matter.FabricSensitivitySensitive
 		}
 		applyErrataToFields(ev.Fields, override)
+		for _, f := range override.ExtraFields {
+			var found bool
+			for _, field := range ev.Fields {
+				if field.Name == f.Name {
+					found = true
+					break
+				}
+			}
+			if !found {
+				field := matter.NewField(nil, ev, types.EntityTypeEventField)
+				field.Name = f.Name
+				if f.Type != "" {
+					var rank types.DataTypeRank = types.DataTypeRankScalar
+					if f.List {
+						rank = types.DataTypeRankList
+					}
+					field.Type = types.ParseDataType(f.Type, rank)
+				}
+				applyErrataToField(field, f)
+				ev.Fields = append(ev.Fields, field)
+			}
+		}
 	}
 	ev.Name = applyTypeName(typeNames, ev.Name)
 

--- a/sdk/errata.go
+++ b/sdk/errata.go
@@ -1,6 +1,7 @@
 package sdk
 
 import (
+	"fmt"
 	"log/slog"
 
 	"github.com/project-chip/alchemy/errata"
@@ -44,23 +45,38 @@ func ApplyErrata(spec *spec.Specification, opts ...ApplyErrataOption) (err error
 		for _, entity := range entities {
 			switch entity := entity.(type) {
 			case *matter.Cluster:
-				applyErrataToCluster(spec, entity, errata.SDK, options)
+				err = applyErrataToCluster(spec, entity, errata.SDK, options)
+				if err != nil {
+					return err
+				}
 			case *matter.Bitmap:
 				applyErrataToBitmap(entity, typeNames, typeOverrides)
 			case *matter.Enum:
 				applyErrataToEnum(entity, typeNames, typeOverrides)
 			case *matter.Struct:
-				applyErrataToStruct(entity, typeNames, typeOverrides)
+				err = applyErrataToStruct(entity, typeNames, typeOverrides)
+				if err != nil {
+					return err
+				}
 			case *matter.Command:
-				applyErrataToCommand(entity, typeNames, typeOverrides)
+				err = applyErrataToCommand(entity, typeNames, typeOverrides)
+				if err != nil {
+					return err
+				}
 			case *matter.Event:
-				applyErrataToEvent(entity, typeNames, typeOverrides)
+				err = applyErrataToEvent(entity, typeNames, typeOverrides)
+				if err != nil {
+					return err
+				}
 			case *matter.DeviceType:
 				applyErrataToDeviceType(entity, typeOverrides)
 			}
 		}
 		if extraTypes != nil {
-			addExtraTypes(extraTypes, entities)
+			err = addExtraTypes(extraTypes, entities)
+			if err != nil {
+				return err
+			}
 			addedExtraEntities = true
 		}
 	}
@@ -73,11 +89,11 @@ func ApplyErrata(spec *spec.Specification, opts ...ApplyErrataOption) (err error
 	return
 }
 
-func applyErrataToCommand(st *matter.Command, typeNames map[string]string, typeOverrides *errata.SDKTypes) {
+func applyErrataToCommand(st *matter.Command, typeNames map[string]string, typeOverrides *errata.SDKTypes) error {
 	if typeOverrides != nil {
 		override, ok := typeOverrides.Commands[st.Name]
 		if !ok {
-			return
+			return nil
 		}
 		if override.OverrideName != "" {
 			st.Name = override.OverrideName
@@ -111,38 +127,24 @@ func applyErrataToCommand(st *matter.Command, typeNames map[string]string, typeO
 				}
 			}
 		}
-		applyErrataToFields(st.Fields, override)
-		for _, f := range override.ExtraFields {
-			var found bool
-			for _, field := range st.Fields {
-				if field.Name == f.Name {
-					found = true
-					break
-				}
-			}
-			if !found {
-				field := matter.NewField(nil, st, types.EntityTypeCommandField)
-				field.Name = f.Name
-				if f.Type != "" {
-					var rank types.DataTypeRank = types.DataTypeRankScalar
-					if f.List {
-						rank = types.DataTypeRankList
-					}
-					field.Type = types.ParseDataType(f.Type, rank)
-				}
-				applyErrataToField(field, f)
-				st.Fields = append(st.Fields, field)
-			}
+		err := applyErrataToFields(st.Fields, override)
+		if err != nil {
+			return err
+		}
+		err = injectExtraFields(st, &st.Fields, types.EntityTypeCommandField, override.ExtraFields)
+		if err != nil {
+			return err
 		}
 	}
 	st.Name = applyTypeName(typeNames, st.Name)
+	return nil
 }
 
-func applyErrataToEvent(ev *matter.Event, typeNames map[string]string, typeOverrides *errata.SDKTypes) {
+func applyErrataToEvent(ev *matter.Event, typeNames map[string]string, typeOverrides *errata.SDKTypes) error {
 	if typeOverrides != nil {
 		override, ok := typeOverrides.Events[ev.Name]
 		if !ok {
-			return
+			return nil
 		}
 		if override.OverrideName != "" {
 			ev.Name = override.OverrideName
@@ -168,32 +170,17 @@ func applyErrataToEvent(ev *matter.Event, typeNames map[string]string, typeOverr
 		case "fabric-sensitive":
 			ev.Access.FabricSensitivity = matter.FabricSensitivitySensitive
 		}
-		applyErrataToFields(ev.Fields, override)
-		for _, f := range override.ExtraFields {
-			var found bool
-			for _, field := range ev.Fields {
-				if field.Name == f.Name {
-					found = true
-					break
-				}
-			}
-			if !found {
-				field := matter.NewField(nil, ev, types.EntityTypeEventField)
-				field.Name = f.Name
-				if f.Type != "" {
-					var rank types.DataTypeRank = types.DataTypeRankScalar
-					if f.List {
-						rank = types.DataTypeRankList
-					}
-					field.Type = types.ParseDataType(f.Type, rank)
-				}
-				applyErrataToField(field, f)
-				ev.Fields = append(ev.Fields, field)
-			}
+		err := applyErrataToFields(ev.Fields, override)
+		if err != nil {
+			return err
+		}
+		err = injectExtraFields(ev, &ev.Fields, types.EntityTypeEventField, override.ExtraFields)
+		if err != nil {
+			return err
 		}
 	}
 	ev.Name = applyTypeName(typeNames, ev.Name)
-
+	return nil
 }
 
 func applyErrataToDeviceType(deviceType *matter.DeviceType, typeOverrides *errata.SDKTypes) {
@@ -228,18 +215,18 @@ func overrideQuality(override *errata.SDKType, defaultQuality matter.Quality) ma
 	}
 }
 
-func overrideAccess(override *errata.SDKType, entityType types.EntityType, defaultAccess matter.Access) matter.Access {
+func overrideAccess(override *errata.SDKType, entityType types.EntityType, defaultAccess matter.Access) (matter.Access, error) {
 	if override.Access == "" {
-		return defaultAccess
+		return defaultAccess, nil
 	}
 	switch override.Access {
 	case "none":
-		return matter.Access{}
+		return matter.Access{}, nil
 	default:
 		access, parsed := spec.ParseAccess(override.Access, entityType)
 		if parsed {
-			return access
+			return access, nil
 		}
-		return defaultAccess
+		return defaultAccess, fmt.Errorf("failed to parse access string %q for entity type %s", override.Access, entityType)
 	}
 }

--- a/sdk/errata.go
+++ b/sdk/errata.go
@@ -10,7 +10,23 @@ import (
 	"github.com/project-chip/alchemy/matter/types"
 )
 
-func ApplyErrata(spec *spec.Specification) (err error) {
+type ApplyErrataOption func(*applyErrataOptions)
+
+type applyErrataOptions struct {
+	skipSharedEntities bool
+}
+
+func WithSkipSharedEntities(skip bool) ApplyErrataOption {
+	return func(o *applyErrataOptions) {
+		o.skipSharedEntities = skip
+	}
+}
+
+func ApplyErrata(spec *spec.Specification, opts ...ApplyErrataOption) (err error) {
+	var options applyErrataOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
 	var addedExtraEntities bool
 	for path, errata := range spec.Errata.All() {
 		if !errata.SDK.HasSdkPatch() {
@@ -28,7 +44,7 @@ func ApplyErrata(spec *spec.Specification) (err error) {
 		for _, entity := range entities {
 			switch entity := entity.(type) {
 			case *matter.Cluster:
-				applyErrataToCluster(spec, entity, errata.SDK)
+				applyErrataToCluster(spec, entity, errata.SDK, options)
 			case *matter.Bitmap:
 				applyErrataToBitmap(entity, typeNames, typeOverrides)
 			case *matter.Enum:

--- a/sdk/extra.go
+++ b/sdk/extra.go
@@ -139,6 +139,7 @@ func addExtraAttributesAndCommandsToCluster(cluster *matter.Cluster, extraTypes 
 	if override, ok := extraTypes.Clusters[cluster.Name]; ok {
 		addExtraAttributes(cluster, override)
 		addExtraCommands(cluster, override)
+		addExtraEvents(cluster, override)
 	}
 	if len(extraTypes.Attributes) > 0 {
 		addExtraAttributes(cluster, &errata.SDKType{Attributes: extraTypes.Attributes})
@@ -146,7 +147,70 @@ func addExtraAttributesAndCommandsToCluster(cluster *matter.Cluster, extraTypes 
 	if len(extraTypes.Commands) > 0 {
 		addExtraCommands(cluster, &errata.SDKType{Commands: extraTypes.Commands})
 	}
+	if len(extraTypes.Events) > 0 {
+		addExtraEvents(cluster, &errata.SDKType{Events: extraTypes.Events})
+	}
 }
+
+func addExtraEvents(cluster *matter.Cluster, extra *errata.SDKType) {
+	existingEvents := make(map[string]struct{}, len(cluster.Events))
+	for _, ev := range cluster.Events {
+		existingEvents[ev.Name] = struct{}{}
+	}
+
+	for name, ev := range extra.Events {
+		if _, ok := existingEvents[name]; ok {
+			continue
+		}
+		event := matter.NewEvent(nil, cluster)
+		event.Name = name
+		if ev.Value != "" {
+			event.ID = matter.ParseNumber(ev.Value)
+		}
+		if ev.Priority != "" {
+			event.Priority = ev.Priority
+		}
+		if ev.Access != "" {
+			var parsed bool
+			event.Access, parsed = spec.ParseAccess(ev.Access, types.EntityTypeEvent)
+			if !parsed {
+				slog.Warn("failed to parse access string for extra event from errata", slog.String("cluster", cluster.Name), slog.String("event", name), slog.String("access", ev.Access))
+			}
+		}
+		if ev.Conformance != "" {
+			event.Conformance = conformance.ParseConformance(ev.Conformance)
+			resolveExtraConformance(cluster, event.Conformance)
+		}
+		for i, f := range ev.Fields {
+			field := matter.NewField(nil, event, types.EntityTypeEventField)
+			field.Name = f.Name
+			if f.Value != "" {
+				field.ID = matter.ParseNumber(f.Value)
+			} else {
+				field.ID = matter.NewNumber(uint64(i))
+			}
+			var rank types.DataTypeRank
+			if f.List {
+				rank = types.DataTypeRankList
+			}
+			field.Type = types.ParseDataType(f.Type, rank)
+			if f.Constraint != "" {
+				field.Constraint = constraint.ParseString(f.Constraint)
+			}
+			if f.Conformance != "" {
+				field.Conformance = conformance.ParseConformance(f.Conformance)
+				resolveExtraConformance(cluster, field.Conformance)
+			}
+			if f.Fallback != "" {
+				field.Fallback = constraint.ParseLimit(f.Fallback)
+			}
+			event.Fields = append(event.Fields, field)
+		}
+		event.SetParent(cluster)
+		cluster.Events = append(cluster.Events, event)
+	}
+}
+
 
 func addExtraAttributes(cluster *matter.Cluster, extra *errata.SDKType) {
 	existingAttributes := make(map[string]struct{}, len(cluster.Attributes))

--- a/sdk/extra.go
+++ b/sdk/extra.go
@@ -245,6 +245,26 @@ func addExtraCommands(cluster *matter.Cluster, extra *errata.SDKType) {
 		command.SetParent(cluster)
 		cluster.Commands = append(cluster.Commands, command)
 	}
+
+	// Since addExtraCommands runs after the main type resolution pass, we must
+	// manually resolve the response command references to their corresponding command entities.
+	for _, command := range cluster.Commands {
+		if command.Response != nil && command.Response.Entity == nil && command.Response.Name != "" {
+			var desiredDirection matter.Interface
+			switch command.Direction {
+			case matter.InterfaceServer:
+				desiredDirection = matter.InterfaceClient
+			case matter.InterfaceClient:
+				desiredDirection = matter.InterfaceServer
+			}
+			for _, cmd := range cluster.Commands {
+				if cmd.Direction == desiredDirection && cmd.Name == command.Response.Name {
+					command.Response.Entity = cmd
+					break
+				}
+			}
+		}
+	}
 }
 
 func resolveExtraConformance(cluster *matter.Cluster, conf conformance.Conformance) {

--- a/sdk/extra.go
+++ b/sdk/extra.go
@@ -57,9 +57,19 @@ func addExtraTypes(extraTypes *errata.SDKTypes, entities []types.Entity) {
 		s := matter.NewStruct(nil, nil)
 		s.Name = name
 		s.Description = es.Description
+		switch es.FabricScoping {
+		case "unscoped":
+			s.FabricScoping = matter.FabricScopingUnscoped
+		case "scoped":
+			s.FabricScoping = matter.FabricScopingScoped
+		}
 		for i, ef := range es.Fields {
 			f := matter.NewField(nil, s, types.EntityTypeStructField)
-			f.ID = matter.NewNumber(uint64(i))
+			if ef.Value != "" {
+				f.ID = matter.ParseNumber(ef.Value)
+			} else {
+				f.ID = matter.NewNumber(uint64(i))
+			}
 			f.Name = ef.Name
 			var rank types.DataTypeRank
 			if ef.List {
@@ -71,8 +81,9 @@ func addExtraTypes(extraTypes *errata.SDKTypes, entities []types.Entity) {
 			}
 			if ef.Conformance != "" {
 				f.Conformance = conformance.ParseConformance(ef.Conformance)
+			} else {
+				f.Conformance = conformance.Set{&conformance.Mandatory{}}
 			}
-			f.Conformance = conformance.Set{&conformance.Mandatory{}}
 			s.Fields = append(s.Fields, f)
 		}
 		extraEntities = append(extraEntities, s)
@@ -153,7 +164,11 @@ func addExtraAttributes(cluster *matter.Cluster, extra *errata.SDKType) {
 			field.ID = matter.ParseNumber(a.Value)
 		}
 		if a.Type != "" {
-			field.Type = types.ParseDataType(a.Type, types.DataTypeRankScalar)
+			var rank types.DataTypeRank = types.DataTypeRankScalar
+			if a.List {
+				rank = types.DataTypeRankList
+			}
+			field.Type = types.ParseDataType(a.Type, rank)
 		}
 		if a.Access != "" {
 			var parsed bool

--- a/sdk/extra.go
+++ b/sdk/extra.go
@@ -1,7 +1,7 @@
 package sdk
 
 import (
-	"log/slog"
+	"fmt"
 
 	"github.com/project-chip/alchemy/errata"
 	"github.com/project-chip/alchemy/matter"
@@ -11,9 +11,9 @@ import (
 	"github.com/project-chip/alchemy/matter/types"
 )
 
-func addExtraTypes(extraTypes *errata.SDKTypes, entities []types.Entity) {
+func addExtraTypes(extraTypes *errata.SDKTypes, entities []types.Entity) error {
 	if extraTypes == nil {
-		return
+		return nil
 	}
 
 	var extraEntities []types.Entity
@@ -92,18 +92,25 @@ func addExtraTypes(extraTypes *errata.SDKTypes, entities []types.Entity) {
 		switch v := m.(type) {
 		case *matter.ClusterGroup:
 			for _, cl := range v.Clusters {
-				addExtraAttributesAndCommandsToCluster(cl, extraTypes)
+				err := addExtraAttributesAndCommandsToCluster(cl, extraTypes)
+				if err != nil {
+					return err
+				}
 				for _, e := range extraEntities {
 					addExtraEntity(cl, e)
 				}
 			}
 		case *matter.Cluster:
-			addExtraAttributesAndCommandsToCluster(v, extraTypes)
+			err := addExtraAttributesAndCommandsToCluster(v, extraTypes)
+			if err != nil {
+				return err
+			}
 			for _, e := range extraEntities {
 				addExtraEntity(v, e)
 			}
 		}
 	}
+	return nil
 }
 
 func addExtraEntity(cluster *matter.Cluster, e types.Entity) {
@@ -135,24 +142,43 @@ func addExtraEntity(cluster *matter.Cluster, e types.Entity) {
 	}
 }
 
-func addExtraAttributesAndCommandsToCluster(cluster *matter.Cluster, extraTypes *errata.SDKTypes) {
+func addExtraAttributesAndCommandsToCluster(cluster *matter.Cluster, extraTypes *errata.SDKTypes) error {
 	if override, ok := extraTypes.Clusters[cluster.Name]; ok {
-		addExtraAttributes(cluster, override)
-		addExtraCommands(cluster, override)
-		addExtraEvents(cluster, override)
+		err := addExtraAttributes(cluster, override)
+		if err != nil {
+			return err
+		}
+		err = addExtraCommands(cluster, override)
+		if err != nil {
+			return err
+		}
+		err = addExtraEvents(cluster, override)
+		if err != nil {
+			return err
+		}
 	}
 	if len(extraTypes.Attributes) > 0 {
-		addExtraAttributes(cluster, &errata.SDKType{Attributes: extraTypes.Attributes})
+		err := addExtraAttributes(cluster, &errata.SDKType{Attributes: extraTypes.Attributes})
+		if err != nil {
+			return err
+		}
 	}
 	if len(extraTypes.Commands) > 0 {
-		addExtraCommands(cluster, &errata.SDKType{Commands: extraTypes.Commands})
+		err := addExtraCommands(cluster, &errata.SDKType{Commands: extraTypes.Commands})
+		if err != nil {
+			return err
+		}
 	}
 	if len(extraTypes.Events) > 0 {
-		addExtraEvents(cluster, &errata.SDKType{Events: extraTypes.Events})
+		err := addExtraEvents(cluster, &errata.SDKType{Events: extraTypes.Events})
+		if err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
-func addExtraEvents(cluster *matter.Cluster, extra *errata.SDKType) {
+func addExtraEvents(cluster *matter.Cluster, extra *errata.SDKType) error {
 	existingEvents := make(map[string]struct{}, len(cluster.Events))
 	for _, ev := range cluster.Events {
 		existingEvents[ev.Name] = struct{}{}
@@ -174,7 +200,7 @@ func addExtraEvents(cluster *matter.Cluster, extra *errata.SDKType) {
 			var parsed bool
 			event.Access, parsed = spec.ParseAccess(ev.Access, types.EntityTypeEvent)
 			if !parsed {
-				slog.Warn("failed to parse access string for extra event from errata", slog.String("cluster", cluster.Name), slog.String("event", name), slog.String("access", ev.Access))
+				return fmt.Errorf("failed to parse access string %q for extra event %s in cluster %s from errata", ev.Access, name, cluster.Name)
 			}
 		}
 		if ev.Conformance != "" {
@@ -209,10 +235,11 @@ func addExtraEvents(cluster *matter.Cluster, extra *errata.SDKType) {
 		event.SetParent(cluster)
 		cluster.Events = append(cluster.Events, event)
 	}
+	return nil
 }
 
 
-func addExtraAttributes(cluster *matter.Cluster, extra *errata.SDKType) {
+func addExtraAttributes(cluster *matter.Cluster, extra *errata.SDKType) error {
 	existingAttributes := make(map[string]struct{}, len(cluster.Attributes))
 	for _, f := range cluster.Attributes {
 		existingAttributes[f.Name] = struct{}{}
@@ -238,7 +265,7 @@ func addExtraAttributes(cluster *matter.Cluster, extra *errata.SDKType) {
 			var parsed bool
 			field.Access, parsed = spec.ParseAccess(a.Access, types.EntityTypeAttribute)
 			if !parsed {
-				slog.Warn("failed to parse access string for extra attribute from errata", slog.String("cluster", cluster.Name), slog.String("attribute", name), slog.String("access", a.Access))
+				return fmt.Errorf("failed to parse access string %q for extra attribute %s in cluster %s from errata", a.Access, name, cluster.Name)
 			}
 		}
 		if a.Conformance != "" {
@@ -257,9 +284,10 @@ func addExtraAttributes(cluster *matter.Cluster, extra *errata.SDKType) {
 		field.SetParent(cluster)
 		cluster.Attributes = append(cluster.Attributes, field)
 	}
+	return nil
 }
 
-func addExtraCommands(cluster *matter.Cluster, extra *errata.SDKType) {
+func addExtraCommands(cluster *matter.Cluster, extra *errata.SDKType) error {
 	existingCommands := make(map[string]struct{}, len(cluster.Commands))
 	for _, cmd := range cluster.Commands {
 		existingCommands[cmd.Name] = struct{}{}
@@ -278,7 +306,7 @@ func addExtraCommands(cluster *matter.Cluster, extra *errata.SDKType) {
 			var parsed bool
 			command.Access, parsed = spec.ParseAccess(cmd.Access, types.EntityTypeCommand)
 			if !parsed {
-				slog.Warn("failed to parse access string for extra command from errata", slog.String("cluster", cluster.Name), slog.String("command", name), slog.String("access", cmd.Access))
+				return fmt.Errorf("failed to parse access string %q for extra command %s in cluster %s from errata", cmd.Access, name, cluster.Name)
 			}
 		}
 		if cmd.Conformance != "" {
@@ -344,6 +372,7 @@ func addExtraCommands(cluster *matter.Cluster, extra *errata.SDKType) {
 			}
 		}
 	}
+	return nil
 }
 
 func resolveExtraConformance(cluster *matter.Cluster, conf conformance.Conformance) {

--- a/sdk/struct.go
+++ b/sdk/struct.go
@@ -8,11 +8,11 @@ import (
 	"github.com/project-chip/alchemy/matter/types"
 )
 
-func applyErrataToStruct(st *matter.Struct, typeNames map[string]string, typeOverrides *errata.SDKTypes) {
+func applyErrataToStruct(st *matter.Struct, typeNames map[string]string, typeOverrides *errata.SDKTypes) error {
 	if typeOverrides != nil {
 		ast, ok := typeOverrides.Structs[st.Name]
 		if !ok {
-			return
+			return nil
 		}
 		if ast.OverrideName != "" {
 			st.Name = ast.OverrideName
@@ -23,48 +23,66 @@ func applyErrataToStruct(st *matter.Struct, typeNames map[string]string, typeOve
 		case "fabric-scoped":
 			st.FabricScoping = matter.FabricScopingScoped
 		}
-		applyErrataToFields(st.Fields, ast)
-		for _, f := range ast.ExtraFields {
-			var found bool
-			for _, field := range st.Fields {
-				if field.Name == f.Name {
-					found = true
-					break
-				}
-			}
-			if !found {
-				field := matter.NewField(nil, st, types.EntityTypeStructField)
-				field.Name = f.Name
-				if f.Type != "" {
-					var rank types.DataTypeRank = types.DataTypeRankScalar
-					if f.List {
-						rank = types.DataTypeRankList
-					}
-					field.Type = types.ParseDataType(f.Type, rank)
-				}
-				applyErrataToField(field, f)
-				st.Fields = append(st.Fields, field)
-			}
+		err := applyErrataToFields(st.Fields, ast)
+		if err != nil {
+			return err
+		}
+		err = injectExtraFields(st, &st.Fields, types.EntityTypeStructField, ast.ExtraFields)
+		if err != nil {
+			return err
 		}
 	}
 	st.Name = applyTypeName(typeNames, st.Name)
-
+	return nil
 }
 
-func applyErrataToFields(fs matter.FieldSet, override *errata.SDKType) {
+func injectExtraFields(parent types.Entity, fields *matter.FieldSet, entityType types.EntityType, extraFields []*errata.SDKType) error {
+	for _, f := range extraFields {
+		var found bool
+		for _, field := range *fields {
+			if field.Name == f.Name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			field := matter.NewField(nil, parent, entityType)
+			field.Name = f.Name
+			if f.Type != "" {
+				var rank types.DataTypeRank = types.DataTypeRankScalar
+				if f.List {
+					rank = types.DataTypeRankList
+				}
+				field.Type = types.ParseDataType(f.Type, rank)
+			}
+			err := applyErrataToField(field, f)
+			if err != nil {
+				return err
+			}
+			*fields = append(*fields, field)
+		}
+	}
+	return nil
+}
+
+func applyErrataToFields(fs matter.FieldSet, override *errata.SDKType) error {
 	if len(override.Fields) != 0 {
 		for _, f := range override.Fields {
 			for _, field := range fs {
 				if field.Name == f.Name {
-					applyErrataToField(field, f)
+					err := applyErrataToField(field, f)
+					if err != nil {
+						return err
+					}
 					break
 				}
 			}
 		}
 	}
+	return nil
 }
 
-func applyErrataToField(field *matter.Field, override *errata.SDKType) {
+func applyErrataToField(field *matter.Field, override *errata.SDKType) error {
 	if override.OverrideName != "" {
 		field.Name = override.OverrideName
 	}
@@ -88,5 +106,10 @@ func applyErrataToField(field *matter.Field, override *errata.SDKType) {
 		field.ID = matter.ParseNumber(override.Value)
 	}
 	field.Quality = overrideQuality(override, field.Quality)
-	field.Access = overrideAccess(override, field.EntityType(), field.Access)
+	access, err := overrideAccess(override, field.EntityType(), field.Access)
+	if err != nil {
+		return err
+	}
+	field.Access = access
+	return nil
 }

--- a/sdk/struct.go
+++ b/sdk/struct.go
@@ -24,6 +24,28 @@ func applyErrataToStruct(st *matter.Struct, typeNames map[string]string, typeOve
 			st.FabricScoping = matter.FabricScopingScoped
 		}
 		applyErrataToFields(st.Fields, ast)
+		for _, f := range ast.ExtraFields {
+			var found bool
+			for _, field := range st.Fields {
+				if field.Name == f.Name {
+					found = true
+					break
+				}
+			}
+			if !found {
+				field := matter.NewField(nil, st, types.EntityTypeStructField)
+				field.Name = f.Name
+				if f.Type != "" {
+					var rank types.DataTypeRank = types.DataTypeRankScalar
+					if f.List {
+						rank = types.DataTypeRankList
+					}
+					field.Type = types.ParseDataType(f.Type, rank)
+				}
+				applyErrataToField(field, f)
+				st.Fields = append(st.Fields, field)
+			}
+		}
 	}
 	st.Name = applyTypeName(typeNames, st.Name)
 

--- a/zap/render/field.go
+++ b/zap/render/field.go
@@ -70,7 +70,7 @@ func (cr *configuratorRenderer) getDataTypeString(fs matter.FieldSet, f *matter.
 	case types.BaseDataTypeTag:
 		if f.Type.Entity != nil {
 			if namespace, ok := f.Type.Entity.(*matter.Namespace); ok {
-				return matterNamespaceName(namespace)
+				return matterNamespaceName(cr.configurator.Spec, namespace)
 			}
 		} else {
 			return "enum8"

--- a/zap/render/namespaces.go
+++ b/zap/render/namespaces.go
@@ -58,7 +58,7 @@ func (p NamespacePatcher) Process(cxt context.Context, inputs []*pipeline.Data[*
 		for _, entity := range entities {
 			switch namespace := entity.(type) {
 			case *matter.Namespace:
-				namespacesByName[matterNamespaceName(namespace)] = namespace
+				namespacesByName[matterNamespaceName(p.spec, namespace)] = namespace
 			}
 		}
 
@@ -104,12 +104,19 @@ func (p NamespacePatcher) Process(cxt context.Context, inputs []*pipeline.Data[*
 	return
 }
 
-func matterNamespaceName(ns *matter.Namespace) string {
+func matterNamespaceName(specification *spec.Specification, ns *matter.Namespace) string {
 	name := strings.TrimSpace(text.TrimCaseInsensitivePrefix(text.TrimCaseInsensitiveSuffix(ns.Name, " Namespace"), "Common "))
 	name = matter.Case(name)
 	if name == "Area" {
 		// Backwards compatibility for one namespace
 		name += "Type"
 	}
-	return name + "Tag"
+	name = name + "Tag"
+	if doc, ok := specification.DocRefs[ns]; ok {
+		errata := specification.Errata.Get(doc.Path.Relative)
+		if override, ok := errata.SDK.TypeNames[name]; ok {
+			return override
+		}
+	}
+	return name
 }


### PR DESCRIPTION
# IDL Generator Enhancements, Errata Overlay Extensions, and Fixes

## Summary
This Pull Request introduces several improvements to the Alchemy Matter Specification compiler and IDL rendering engine. It expands the capabilities of the errata overlay (`errata.yaml`), improves data type resolution logic, resolves various edge cases in IDL and ZAP generation, and adds formatting controls for output files.

---

## Key Features & To-Do Items Resolved

### 1. Support for defining and injecting events in errata overlays
* **Task**: Enable users to define new events or append extra fields to existing events in a cluster using the `errata.yaml` configuration.
* **Implementation**: Added `addExtraEvents` in `extra.go` to parse and inject custom events (with their priorities, access, and fields) and added `ExtraFields` parsing in `applyErrataToEvent` in `errata.go`.

### 2. Flexible field extensions (`extraFields`) and array/list support in errata
* **Task**: Allow users to append new fields (`extraFields`), define fields as lists (arrays), specify custom fabric scoping, and enforce specific numeric IDs on custom struct fields within `errata.yaml`.
* **Implementation**: Added parsing for `ExtraFields` to append new field entities in `applyErrataToStruct` (in `struct.go`), `applyErrataToCommand`, and `applyErrataToEvent` (in `errata.go`), and added support for checking the `List` and `FabricScoping` attributes to correctly parse and configure them.

### 3. Improved data type resolution for errata-defined and overridden types
* **Task**: Ensure entities and data types added or modified via errata overlays are fully integrated with the type resolution engine.
* **Implementation**: 
  1. Implemented a second type-resolution pass (`ResolveDataTypeReferences()`, etc.) inside `sdk.ApplyErrata` to run after errata overlays are applied.
  2. Mapped ZAP-specific data types (like `int8u`, `int16u`, `bitmap8`, etc.) to standard Matter types in `ParseDataTypeName` (in `data.go`) so they resolve without compiler errors.
  3. Corrected struct inheritance type mappings by removing pointer reference copying in `DataType.Clone()`.

### 4. Correct provisional classification and naming for the "Features" bitmap
* **Task**: Prevent the stable `Feature` bitmap of a cluster from being incorrectly marked as provisional and stripped when individual feature bits are provisional. Also, resolve name discrepancies (e.g. `Features` vs `Feature`) to ensure all bitmap references link correctly.
* **Implementation**: Bypassed provisional checking in `isProvisional` (in `entities.go`) if the entity is `"Feature"` or `"Features"`, and normalized `"Features"` name strings to `"Feature"` in the `entityPath` helper.

### 5. Enhanced existing IDL parsing to handle complex access qualifiers and events
* **Task**: Harden the `.matter` parser to successfully recognize and preserve elements that use inline access control modifiers (like `access(invoke: administer)`) and complex event definitions containing multiple qualifiers during `keep-existing` processing.
* **Implementation**: Updated `parseExistingMatterElements` in `entities.go` to strip out `access(...)` inline blocks before keyword parsing, and refactored event name parsing to extract the name by splitting on the `=` sign.

### 6. Grouped request and response command pairs in generated IDL
* **Task**: Group client-side request commands and server-side response commands together in generated `.matter` files instead of sorting them strictly by their numeric IDs.
* **Implementation**: Modified command sorting logic in `command.go` to look up the request command's ID and use it as the sorting ID for its corresponding response command, keeping them grouped continuously.

### 7. Ensure LabelStruct definition is copied to User Label cluster
* **Task**: Ensure `LabelStruct` is copied to both `Fixed Label` and `User Label` clusters to match ZAP XML expectations.
* **Implementation**: Updated `patchLabelCluster` in `patch.go` to clone `LabelStruct` and move it to the `User Label` cluster, and updated the fields of the `User Label` cluster to reference the cloned copy.

### 8. Change default value of `suppress-provisional` flag to `"all"`
* **Task**: Change the default behavior of the `--suppress-provisional` command line flag to default to `"all"`, so that IDL files generated by default do not render provisional features.
* **Implementation**: Updated the struct tags for `SuppressProvisional` in both the `IDLRegen` and `IDLControllerClusters` command structures in `idl.go` to set `default:"all"`.

### 9. Render `optional` keyword for commands and events with optional conformance
* **Task**: Render the `optional` keyword for commands and events that have optional conformance in output `.matter` files, matching standard Matter IDL schema.
* **Implementation**: Updated `command.handlebars` and `event.handlebars` templates to check `#ifOptional` of `Conformance` and output the `optional` keyword prior to the entity name.

---

## Testing
* Validated that ZAP XML generation compiles successfully with correct changes.
* Verified the generated `.matter` IDL outputs compile successfully and match expected formatting improvements (grouped commands, correct optional qualifiers).
