### PR TITLE
Per-Trait IDL generation

### DIFF
--- a/cmd/cli/idl.go
+++ b/cmd/cli/idl.go
@@ -88,7 +88,7 @@ type IDLControllerClusters struct {
 	files.OutputOptions        `embed:""`
 	spec.ParserOptions         `embed:""`
 	Output                     string `name:"output" placeholder:"path" help:"Output file or directory for controller-clusters.matter" optional:"" default:"controller-clusters.matter"`
-	SuppressProvisional        string `name:"suppress-provisional" help:"Suppress rendering of provisional elements" default:"all" enum:"none,all,keep-existing"`
+	SuppressProvisional        string `name:"suppress-provisional" help:"Suppress rendering of provisional elements" default:"all" enum:"none,all"`
 	PerTrait                   bool   `name:"per-trait" help:"Generate a separate IDL file for each cluster"`
 }
 

--- a/cmd/cli/idl.go
+++ b/cmd/cli/idl.go
@@ -16,7 +16,7 @@ import (
 )
 
 type IDL struct {
-	IDLRegen           IDLRegen              `cmd:"" name:"regen"`
+	IDLRegen              IDLRegen              `cmd:"" name:"regen"`
 	IDLControllerClusters IDLControllerClusters `cmd:"" name:"controller-clusters"`
 }
 

--- a/cmd/cli/idl.go
+++ b/cmd/cli/idl.go
@@ -87,7 +87,7 @@ type IDLControllerClusters struct {
 	pipeline.ProcessingOptions `embed:""`
 	files.OutputOptions        `embed:""`
 	spec.ParserOptions         `embed:""`
-	Output                     string `name:"output" placeholder:"path" help:"Output file or directory for controller-clusters.matter" optional:"" default:"controller-clusters.matter"`
+	Output                     string `name:"output" placeholder:"path" help:"Output file (or directory if --per-trait is used) for controller-clusters.matter" optional:"" default:"controller-clusters.matter"`
 	SuppressProvisional        string `name:"suppress-provisional" help:"Suppress rendering of provisional elements" default:"all" enum:"none,all"`
 	PerTrait                   bool   `name:"per-trait" help:"Generate a separate IDL file for each cluster"`
 }
@@ -153,6 +153,10 @@ func (z *IDLControllerClusters) Run(cc *Context) (err error) {
 	if fi, err := os.Stat(outPath); err == nil {
 		isDir = fi.IsDir()
 	} else if strings.HasSuffix(z.Output, "/") || strings.HasSuffix(z.Output, string(filepath.Separator)) {
+		isDir = true
+	}
+
+	if z.PerTrait {
 		isDir = true
 	}
 

--- a/cmd/cli/idl.go
+++ b/cmd/cli/idl.go
@@ -89,6 +89,7 @@ type IDLControllerClusters struct {
 	spec.ParserOptions         `embed:""`
 	Output                     string `name:"output" placeholder:"path" help:"Output file or directory for controller-clusters.matter" optional:"" default:"controller-clusters.matter"`
 	SuppressProvisional        string `name:"suppress-provisional" help:"Suppress rendering of provisional elements" default:"all" enum:"none,all,keep-existing"`
+	PerTrait                   bool   `name:"per-trait" help:"Generate a separate IDL file for each cluster"`
 }
 
 func (z *IDLControllerClusters) Run(cc *Context) (err error) {
@@ -144,6 +145,7 @@ func (z *IDLControllerClusters) Run(cc *Context) (err error) {
 	}
 	renderer.SuppressEndpoints = true
 	renderer.SuppressProvisional = z.SuppressProvisional
+	renderer.PerTrait = z.PerTrait
 
 	var zapPath string
 	outPath := filepath.Clean(z.Output)
@@ -178,7 +180,9 @@ func (z *IDLControllerClusters) Run(cc *Context) (err error) {
 	writer := files.NewWriter[string]("Writing controller-clusters.matter", z.OutputOptions)
 
 	outputSet := pipeline.StringSet(pipeline.NewMap[string, *pipeline.Data[string]]())
-	outputSet.Store(outputs[0].Path, outputs[0])
+	for _, o := range outputs {
+		outputSet.Store(o.Path, o)
+	}
 
 	return writer.Write(cc, outputSet, z.ProcessingOptions)
 }

--- a/errata/sdk.go
+++ b/errata/sdk.go
@@ -92,6 +92,9 @@ type SDKType struct {
 	OverrideName string `yaml:"override-name,omitempty"`
 	OverrideType string `yaml:"override-type,omitempty"`
 	List         bool   `yaml:"list,omitempty"`
+	Keep         bool   `yaml:"keep,omitempty"`
+	ForceGlobal  bool   `yaml:"force-global,omitempty"`
+	ForceLocal   bool   `yaml:"force-local,omitempty"`
 
 	Fields      []*SDKType `yaml:"fields,omitempty"`
 	ExtraFields []*SDKType `yaml:"extra-fields,omitempty"`

--- a/idl/entities.go
+++ b/idl/entities.go
@@ -1,7 +1,6 @@
 package idl
 
 import (
-	"os"
 	"strings"
 
 	"github.com/mailgun/raymond/v2"
@@ -14,8 +13,7 @@ import (
 )
 
 type ProvisionalFilter struct {
-	Mode             string
-	ExistingElements map[string]bool
+	Mode string
 }
 
 func entityShouldBeIncluded(spec *spec.Specification, filter ProvisionalFilter, e types.Entity) bool {
@@ -29,9 +27,6 @@ func entityShouldBeIncluded(spec *spec.Specification, filter ProvisionalFilter, 
 	}
 
 	if filter.Mode != "none" && isProvisional(spec, e) {
-		if filter.Mode == "keep-existing" && isElementPresent(filter.ExistingElements, e) {
-			return true
-		}
 		return false
 	}
 	return true
@@ -258,205 +253,4 @@ func entityPath(e types.Entity) string {
 	return strings.Join(parts, ".")
 }
 
-func isElementPresent(existing map[string]bool, e types.Entity) bool {
-	if len(existing) == 0 {
-		return false
-	}
-	path := strings.ToLower(entityPath(e))
-	return existing[path]
-}
 
-func parseExistingMatterElements(path string) (map[string]bool, error) {
-	elements := make(map[string]bool)
-	contentBytes, err := os.ReadFile(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return elements, nil
-		}
-		return nil, err
-	}
-	content := string(contentBytes)
-	lines := strings.Split(content, "\n")
-
-	var currentCluster string
-
-	type blockContext struct {
-		blockType string
-		blockName string
-	}
-	var stack []blockContext
-
-	getCurrentPath := func(name string) string {
-		var pathParts []string
-		if currentCluster != "" {
-			pathParts = append(pathParts, currentCluster)
-		}
-		for _, ctx := range stack {
-			if ctx.blockType != "cluster" && ctx.blockName != "" {
-				if ctx.blockType == "event" || ctx.blockType == "command" || ctx.blockType == "attribute" {
-					pathParts = append(pathParts, ctx.blockType, ctx.blockName)
-				} else {
-					pathParts = append(pathParts, ctx.blockName)
-				}
-			}
-		}
-		if name != "" {
-			pathParts = append(pathParts, name)
-		}
-		return strings.ToLower(strings.Join(pathParts, "."))
-	}
-
-	for _, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if trimmed == "" || strings.HasPrefix(trimmed, "//") || strings.HasPrefix(trimmed, "/*") || strings.HasPrefix(trimmed, "*") {
-			continue
-		}
-		for {
-			accessIdx := strings.Index(trimmed, "access(")
-			if accessIdx == -1 {
-				break
-			}
-			depth := 1
-			closeIdx := -1
-			startSearch := accessIdx + len("access(")
-			for i := startSearch; i < len(trimmed); i++ {
-				if trimmed[i] == '(' {
-					depth++
-				} else if trimmed[i] == ')' {
-					depth--
-					if depth == 0 {
-						closeIdx = i
-						break
-					}
-				}
-			}
-			if closeIdx == -1 {
-				break
-			}
-			trimmed = trimmed[:accessIdx] + " " + trimmed[closeIdx+1:]
-		}
-
-		if strings.HasPrefix(trimmed, "cluster ") || strings.Contains(trimmed, " cluster ") {
-			parts := strings.Fields(trimmed)
-			for idx, word := range parts {
-				if word == "cluster" && idx+1 < len(parts) {
-					name := strings.TrimSuffix(parts[idx+1], "{")
-					currentCluster = strings.TrimSpace(name)
-					elements[strings.ToLower(currentCluster)] = true
-					break
-				}
-			}
-		}
-
-		var declType, declName string
-
-		if strings.HasPrefix(trimmed, "enum ") || strings.Contains(trimmed, " enum ") {
-			parts := strings.Fields(trimmed)
-			for idx, word := range parts {
-				if word == "enum" && idx+1 < len(parts) {
-					name := parts[idx+1]
-					name = strings.Split(name, ":")[0]
-					name = strings.TrimSuffix(name, "{")
-					declName = strings.TrimSpace(name)
-					declType = "enum"
-					break
-				}
-			}
-		} else if strings.HasPrefix(trimmed, "bitmap ") || strings.Contains(trimmed, " bitmap ") {
-			parts := strings.Fields(trimmed)
-			for idx, word := range parts {
-				if word == "bitmap" && idx+1 < len(parts) {
-					name := parts[idx+1]
-					name = strings.Split(name, ":")[0]
-					name = strings.TrimSuffix(name, "{")
-					declName = strings.TrimSpace(name)
-					declType = "bitmap"
-					break
-				}
-			}
-		} else if (strings.HasPrefix(trimmed, "struct ") || strings.Contains(trimmed, " struct ")) && !strings.Contains(trimmed, "attribute ") {
-			parts := strings.Fields(trimmed)
-			for idx, word := range parts {
-				if word == "struct" && idx+1 < len(parts) {
-					name := parts[idx+1]
-					name = strings.TrimSuffix(name, "{")
-					name = strings.Split(name, "=")[0]
-					declName = strings.TrimSpace(name)
-					declType = "struct"
-					break
-				}
-			}
-		} else if strings.Contains(trimmed, " event ") && !strings.Contains(trimmed, "attribute ") && !strings.Contains(trimmed, "command ") {
-			eqIdx := strings.Index(trimmed, "=")
-			if eqIdx != -1 {
-				left := strings.TrimSpace(trimmed[:eqIdx])
-				parts := strings.Fields(left)
-				if len(parts) > 0 {
-					name := parts[len(parts)-1]
-					declName = strings.TrimSpace(name)
-					declType = "event"
-				}
-			}
-		} else if strings.Contains(trimmed, "attribute ") {
-			eqIdx := strings.Index(trimmed, "=")
-			if eqIdx != -1 {
-				left := strings.TrimSpace(trimmed[:eqIdx])
-				parts := strings.Fields(left)
-				if len(parts) > 0 {
-					name := parts[len(parts)-1]
-					name = strings.TrimSuffix(name, "[]")
-					attrName := strings.TrimSpace(name)
-					elements[getCurrentPath("attribute."+attrName)] = true
-				}
-			}
-		} else if strings.Contains(trimmed, "command ") {
-			parenIdx := strings.Index(trimmed, "(")
-			if parenIdx != -1 {
-				left := strings.TrimSpace(trimmed[:parenIdx])
-				parts := strings.Fields(left)
-				if len(parts) > 0 {
-					cmdName := strings.TrimSpace(parts[len(parts)-1])
-					elements[getCurrentPath("command."+cmdName)] = true
-				}
-			}
-		} else if len(stack) > 0 {
-			top := stack[len(stack)-1]
-			if top.blockType == "enum" || top.blockType == "bitmap" || top.blockType == "struct" || top.blockType == "event" {
-				eqIdx := strings.Index(trimmed, "=")
-				if eqIdx != -1 {
-					left := strings.TrimSpace(trimmed[:eqIdx])
-					parts := strings.Fields(left)
-					if len(parts) > 0 {
-						name := parts[len(parts)-1]
-						name = strings.TrimSuffix(name, "[]")
-						fieldName := strings.TrimSpace(name)
-						if (top.blockType == "enum" || top.blockType == "bitmap") && len(fieldName) > 1 && fieldName[0] == 'k' && fieldName[1] >= 'A' && fieldName[1] <= 'Z' {
-							fieldName = fieldName[1:]
-						}
-						elements[getCurrentPath(fieldName)] = true
-					}
-				}
-			}
-		}
-
-		openBraces := strings.Count(trimmed, "{")
-		closeBraces := strings.Count(trimmed, "}")
-
-		for o := 0; o < openBraces; o++ {
-			if declType != "" && declName != "" {
-				stack = append(stack, blockContext{blockType: declType, blockName: declName})
-				elements[getCurrentPath("")] = true
-				declType = ""
-				declName = ""
-			} else {
-				stack = append(stack, blockContext{})
-			}
-		}
-		for c := 0; c < closeBraces; c++ {
-			if len(stack) > 0 {
-				stack = stack[:len(stack)-1]
-			}
-		}
-	}
-	return elements, nil
-}

--- a/idl/entities.go
+++ b/idl/entities.go
@@ -254,5 +254,3 @@ func entityPath(e types.Entity) string {
 	}
 	return strings.Join(parts, ".")
 }
-
-

--- a/idl/entities.go
+++ b/idl/entities.go
@@ -24,6 +24,10 @@ func entityShouldBeIncluded(spec *spec.Specification, filter ProvisionalFilter, 
 		return false
 	}
 
+	if isKeptByErrata(spec, e) {
+		return true
+	}
+
 	if filter.Mode != "none" && isProvisional(spec, e) {
 		if filter.Mode == "keep-existing" && isElementPresent(filter.ExistingElements, e) {
 			return true
@@ -114,6 +118,54 @@ func isShared(spec *spec.Specification, en types.Entity) bool {
 	case *matter.Bitmap:
 		_, ok = errata.SDK.SharedBitmaps[name]
 		return ok
+	}
+	return false
+}
+
+func isKeptByErrata(spec *spec.Specification, entity types.Entity) bool {
+	if spec != nil {
+		var parentCluster *matter.Cluster
+		curr := entity
+		for curr != nil {
+			if c, ok := curr.(*matter.Cluster); ok {
+				parentCluster = c
+				break
+			}
+			curr = curr.Parent()
+		}
+		if parentCluster != nil {
+			if doc, ok := spec.DocRefs[parentCluster]; ok {
+				if errata := spec.Errata.Get(doc.Path.Relative); errata != nil && errata.SDK.Types != nil {
+					name := matter.EntityName(entity)
+					switch entity.(type) {
+					case *matter.Field:
+						if entry, ok := errata.SDK.Types.Attributes[name]; ok && entry.Keep {
+							return true
+						}
+					case *matter.Command:
+						if entry, ok := errata.SDK.Types.Commands[name]; ok && entry.Keep {
+							return true
+						}
+					case *matter.Event:
+						if entry, ok := errata.SDK.Types.Events[name]; ok && entry.Keep {
+							return true
+						}
+					case *matter.Enum:
+						if entry, ok := errata.SDK.Types.Enums[name]; ok && entry.Keep {
+							return true
+						}
+					case *matter.Bitmap:
+						if entry, ok := errata.SDK.Types.Bitmaps[name]; ok && entry.Keep {
+							return true
+						}
+					case *matter.Struct:
+						if entry, ok := errata.SDK.Types.Structs[name]; ok && entry.Keep {
+							return true
+						}
+					}
+				}
+			}
+		}
 	}
 	return false
 }

--- a/idl/entities.go
+++ b/idl/entities.go
@@ -130,32 +130,34 @@ func isKeptByErrata(spec *spec.Specification, entity types.Entity) bool {
 		}
 		if parentCluster != nil {
 			if doc, ok := spec.DocRefs[parentCluster]; ok {
-				if errata := spec.Errata.Get(doc.Path.Relative); errata != nil && errata.SDK.Types != nil {
-					name := matter.EntityName(entity)
-					switch entity.(type) {
-					case *matter.Field:
-						if entry, ok := errata.SDK.Types.Attributes[name]; ok && entry.Keep {
-							return true
-						}
-					case *matter.Command:
-						if entry, ok := errata.SDK.Types.Commands[name]; ok && entry.Keep {
-							return true
-						}
-					case *matter.Event:
-						if entry, ok := errata.SDK.Types.Events[name]; ok && entry.Keep {
-							return true
-						}
-					case *matter.Enum:
-						if entry, ok := errata.SDK.Types.Enums[name]; ok && entry.Keep {
-							return true
-						}
-					case *matter.Bitmap:
-						if entry, ok := errata.SDK.Types.Bitmaps[name]; ok && entry.Keep {
-							return true
-						}
-					case *matter.Struct:
-						if entry, ok := errata.SDK.Types.Structs[name]; ok && entry.Keep {
-							return true
+				if spec.Errata != nil {
+					if errata := spec.Errata.Get(doc.Path.Relative); errata != nil && errata.SDK.Types != nil {
+						name := matter.EntityName(entity)
+						switch entity.(type) {
+						case *matter.Field:
+							if entry, ok := errata.SDK.Types.Attributes[name]; ok && entry.Keep {
+								return true
+							}
+						case *matter.Command:
+							if entry, ok := errata.SDK.Types.Commands[name]; ok && entry.Keep {
+								return true
+							}
+						case *matter.Event:
+							if entry, ok := errata.SDK.Types.Events[name]; ok && entry.Keep {
+								return true
+							}
+						case *matter.Enum:
+							if entry, ok := errata.SDK.Types.Enums[name]; ok && entry.Keep {
+								return true
+							}
+						case *matter.Bitmap:
+							if entry, ok := errata.SDK.Types.Bitmaps[name]; ok && entry.Keep {
+								return true
+							}
+						case *matter.Struct:
+							if entry, ok := errata.SDK.Types.Structs[name]; ok && entry.Keep {
+								return true
+							}
 						}
 					}
 				}

--- a/idl/entities_test.go
+++ b/idl/entities_test.go
@@ -1,122 +1,10 @@
 package idl
 
 import (
-	"os"
-	"path/filepath"
-	"reflect"
 	"testing"
 
 	"github.com/project-chip/alchemy/matter"
 )
-
-func TestParseExistingMatterElements(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "matter-test-*")
-	if err != nil {
-		t.Fatalf("failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
-
-	matterFileContent := `
-// Some comments
-/* More comments */
-cluster DoorLock = 257 {
-  revision 1;
-
-  enum DoorStateEnum : enum8 {
-    kSecured = 0;
-    kUnsecured = 1;
-  }
-
-  bitmap Feature : bitmap32 {
-    kPinGeneration = 0x1;
-    kRfidCredential = 0x2;
-  }
-
-  struct AccessControlEntryStruct {
-    fabric_idx fabricIndex = 1;
-    privilege privilege = 2;
-    auth_mode authMode = 3;
-  }
-
-  info event event_id = 1 {
-    nullable int32u attributeId = 0;
-    int32u eventId = 1;
-  }
-
-  info event optional opt_event = 2 {
-    int32u someField = 0;
-  }
-
-  readonly attribute DoorStateEnum doorState = 0;
-  attribute int32u pinCodeLength = 1;
-
-  request command LockDoor() = 0;
-  response command LockDoorResponse() = 1;
-  command optional OptCommand() = 2;
-  timed command access(invoke: manage) UpdatePIN(UpdatePINRequest): DefaultSuccess = 3;
-  command access(invoke: administer) ResetPIN() = 4;
-}
-
-cluster BasicInformation = 40 {
-  enum ProductTypeEnum : enum8 {
-    kItem = 0;
-    kService = 1;
-  }
-}
-`
-
-	filePath := filepath.Join(tmpDir, "test.matter")
-	err = os.WriteFile(filePath, []byte(matterFileContent), 0644)
-	if err != nil {
-		t.Fatalf("failed to write test matter file: %v", err)
-	}
-
-	got, err := parseExistingMatterElements(filePath)
-	if err != nil {
-		t.Fatalf("parseExistingMatterElements failed: %v", err)
-	}
-
-	want := map[string]bool{
-		"doorlock":                                             true,
-		"doorlock.doorstateenum":                               true,
-		"doorlock.doorstateenum.secured":                       true,
-		"doorlock.doorstateenum.unsecured":                     true,
-		"doorlock.feature":                                     true,
-		"doorlock.feature.pingeneration":                       true,
-		"doorlock.feature.rfidcredential":                      true,
-		"doorlock.accesscontrolentrystruct":                    true,
-		"doorlock.accesscontrolentrystruct.fabricindex":        true,
-		"doorlock.accesscontrolentrystruct.privilege":          true,
-		"doorlock.accesscontrolentrystruct.authmode":           true,
-		"doorlock.event.event_id":                              true,
-		"doorlock.event.event_id.attributeid":                  true,
-		"doorlock.event.event_id.eventid":                      true,
-		"doorlock.event.opt_event":                             true,
-		"doorlock.event.opt_event.somefield":                   true,
-		"doorlock.attribute.doorstate":                         true,
-		"doorlock.attribute.pincodelength":                     true,
-		"doorlock.command.lockdoor":                            true,
-		"doorlock.command.lockdoorresponse":                    true,
-		"doorlock.command.optcommand":                          true,
-		"doorlock.command.updatepin":                           true,
-		"doorlock.command.resetpin":                            true,
-		"basicinformation":                                     true,
-		"basicinformation.producttypeenum":                     true,
-		"basicinformation.producttypeenum.item":                true,
-		"basicinformation.producttypeenum.service":             true,
-	}
-
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("parseExistingMatterElements returned mismatch.\nGot:\n")
-		for k := range got {
-			t.Logf("  %q: true,", k)
-		}
-		t.Errorf("\nWant:\n")
-		for k := range want {
-			t.Logf("  %q: true,", k)
-		}
-	}
-}
 
 func TestEntityPath(t *testing.T) {
 	cluster := &matter.Cluster{
@@ -141,15 +29,4 @@ func TestEntityPath(t *testing.T) {
 			t.Errorf("entityPath(featureBit) = %q, want %q", got, want)
 		}
 	})
-
-	t.Run("IsElementPresent", func(t *testing.T) {
-		existing := map[string]bool{
-			"doorlock.feature.pingeneration": true,
-		}
-		got := isElementPresent(existing, featureBit)
-		if !got {
-			t.Errorf("isElementPresent() = false, want true")
-		}
-	})
 }
-

--- a/idl/render.go
+++ b/idl/render.go
@@ -3,21 +3,20 @@ package idl
 import (
 	"context"
 	"embed"
-	"log/slog"
-	"path/filepath"
-	"slices"
-	"strings"
-	"github.com/project-chip/alchemy/internal/text"
 	"github.com/mailgun/raymond/v2"
 	"github.com/project-chip/alchemy/asciidoc/parse"
 	"github.com/project-chip/alchemy/internal/handlebars"
 	"github.com/project-chip/alchemy/internal/pipeline"
-
+	"github.com/project-chip/alchemy/internal/text"
 	"github.com/project-chip/alchemy/matter"
 	"github.com/project-chip/alchemy/matter/conformance"
 	"github.com/project-chip/alchemy/matter/spec"
 	"github.com/project-chip/alchemy/matter/types"
 	"github.com/project-chip/alchemy/provisional"
+	"log/slog"
+	"path/filepath"
+	"slices"
+	"strings"
 )
 
 //go:embed templates
@@ -189,8 +188,6 @@ func (p IdlRenderer) Process(cxt context.Context, input *pipeline.Data[*File], i
 		return parse.SearchShouldContinue
 	})
 
-
-
 	for entity, isGlobal := range globalEntities {
 		if !isGlobal {
 			continue
@@ -360,8 +357,6 @@ func (p IdlRenderer) Process(cxt context.Context, input *pipeline.Data[*File], i
 		tc["endpoints"] = nil
 	}
 
-
-
 	var out string
 	out, err = t.Exec(tc)
 	if err != nil {
@@ -456,5 +451,3 @@ func getClusterFileName(clusterName string) string {
 	name = text.ToIDLSnakeCase(name)
 	return name + ".matter"
 }
-
-

--- a/idl/render.go
+++ b/idl/render.go
@@ -7,13 +7,12 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
-	"unicode"
-
+	"github.com/project-chip/alchemy/internal/text"
 	"github.com/mailgun/raymond/v2"
 	"github.com/project-chip/alchemy/asciidoc/parse"
 	"github.com/project-chip/alchemy/internal/handlebars"
 	"github.com/project-chip/alchemy/internal/pipeline"
-	"github.com/project-chip/alchemy/errata"
+
 	"github.com/project-chip/alchemy/matter"
 	"github.com/project-chip/alchemy/matter/conformance"
 	"github.com/project-chip/alchemy/matter/spec"
@@ -190,90 +189,7 @@ func (p IdlRenderer) Process(cxt context.Context, input *pipeline.Data[*File], i
 		return parse.SearchShouldContinue
 	})
 
-	originalToClone := make(map[*matter.Cluster]*matter.Cluster)
-	cloneToOriginal := make(map[*matter.Cluster]*matter.Cluster)
-	for _, ci := range clusterList {
-		originalC := ci.Cluster
-		cClone := *originalC
-		cClone.Enums = slices.Clone(cClone.Enums)
-		cClone.Bitmaps = slices.Clone(cClone.Bitmaps)
-		cClone.Structs = slices.Clone(cClone.Structs)
-		ci.Cluster = &cClone
-		originalToClone[originalC] = &cClone
-		cloneToOriginal[&cClone] = originalC
-	}
 
-	for originalC, ce := range clusterEntities {
-		c := originalToClone[originalC]
-		doc, ok := p.spec.DocRefs[originalC]
-		if !ok {
-			continue
-		}
-		if p.spec.Errata == nil {
-			continue
-		}
-		errata := p.spec.Errata.Get(doc.Path.Relative)
-		if errata == nil || errata.SDK.Types == nil {
-			continue
-		}
-		for name, entry := range errata.SDK.Types.Enums {
-			if entry.ForceLocal {
-				for entity := range globalEntities {
-					if en, ok := entity.(*matter.Enum); ok && en.Name == name {
-						exists := false
-						for _, existing := range c.Enums {
-							if existing.Name == name {
-								exists = true
-								break
-							}
-						}
-						if !exists {
-							ce[entity] = struct{}{}
-							c.Enums = append(c.Enums, en)
-						}
-					}
-				}
-			}
-		}
-		for name, entry := range errata.SDK.Types.Bitmaps {
-			if entry.ForceLocal {
-				for entity := range globalEntities {
-					if bm, ok := entity.(*matter.Bitmap); ok && bm.Name == name {
-						exists := false
-						for _, existing := range c.Bitmaps {
-							if existing.Name == name {
-								exists = true
-								break
-							}
-						}
-						if !exists {
-							ce[entity] = struct{}{}
-							c.Bitmaps = append(c.Bitmaps, bm)
-						}
-					}
-				}
-			}
-		}
-		for name, entry := range errata.SDK.Types.Structs {
-			if entry.ForceLocal {
-				for entity := range globalEntities {
-					if st, ok := entity.(*matter.Struct); ok && st.Name == name {
-						exists := false
-						for _, existing := range c.Structs {
-							if existing.Name == name {
-								exists = true
-								break
-							}
-						}
-						if !exists {
-							ce[entity] = struct{}{}
-							c.Structs = append(c.Structs, st)
-						}
-					}
-				}
-			}
-		}
-	}
 
 	for entity, isGlobal := range globalEntities {
 		if !isGlobal {
@@ -335,33 +251,6 @@ func (p IdlRenderer) Process(cxt context.Context, input *pipeline.Data[*File], i
 			en.Values = append(en.Values, nst)
 		}
 		globalEnums = append(globalEnums, en)
-		for originalC, ce := range clusterEntities {
-			c := originalToClone[originalC]
-			doc, ok := p.spec.DocRefs[originalC]
-			if !ok {
-				continue
-			}
-			if p.spec.Errata == nil {
-				continue
-			}
-			errata := p.spec.Errata.Get(doc.Path.Relative)
-			if errata == nil || errata.SDK.Types == nil {
-				continue
-			}
-			if entry, ok := errata.SDK.Types.Enums[en.Name]; ok && entry.Keep {
-				exists := false
-				for _, existing := range c.Enums {
-					if existing.Name == en.Name {
-						exists = true
-						break
-					}
-				}
-				if !exists {
-					ce[en] = struct{}{}
-					c.Enums = append(c.Enums, en)
-				}
-			}
-		}
 	}
 
 	slices.SortFunc(globalEnums, func(a, b *matter.Enum) int {
@@ -376,16 +265,17 @@ func (p IdlRenderer) Process(cxt context.Context, input *pipeline.Data[*File], i
 		return strings.Compare(a.Name, b.Name)
 	})
 
+	var t *raymond.Template
+	t, err = p.loadTemplate(p.spec)
+	if err != nil {
+		return
+	}
+
 	for _, clusterInfo := range clusterList {
-		originalC := cloneToOriginal[clusterInfo.Cluster]
-		ce, ok := clusterEntities[originalC]
+		c := clusterInfo.Cluster
+		ce, ok := clusterEntities[c]
 		if !ok {
 			continue
-		}
-
-		var errata *errata.Errata
-		if doc, ok := p.spec.DocRefs[originalC]; ok && p.spec.Errata != nil {
-			errata = p.spec.Errata.Get(doc.Path.Relative)
 		}
 
 		ceNames := make(map[string]struct{}, len(ce))
@@ -394,34 +284,69 @@ func (p IdlRenderer) Process(cxt context.Context, input *pipeline.Data[*File], i
 		}
 		for _, s := range clusterInfo.Cluster.Structs {
 			if _, ok := ceNames[s.Name]; ok {
-				if errata != nil && errata.SDK.Types != nil {
-					if entry, ok := errata.SDK.Types.Structs[s.Name]; ok && entry.ForceGlobal {
-						continue
-					}
-				}
 				clusterInfo.ReferencedStructs = append(clusterInfo.ReferencedStructs, s)
 			}
 		}
 		for _, en := range clusterInfo.Cluster.Enums {
 			if _, ok := ceNames[en.Name]; ok {
-				if errata != nil && errata.SDK.Types != nil {
-					if entry, ok := errata.SDK.Types.Enums[en.Name]; ok && entry.ForceGlobal {
-						continue
-					}
-				}
 				clusterInfo.ReferencedEnums = append(clusterInfo.ReferencedEnums, en)
 			}
 		}
 		for _, bm := range clusterInfo.Cluster.Bitmaps {
 			if _, ok := ceNames[bm.Name]; ok {
-				if errata != nil && errata.SDK.Types != nil {
-					if entry, ok := errata.SDK.Types.Bitmaps[bm.Name]; ok && entry.ForceGlobal {
-						continue
-					}
-				}
 				clusterInfo.ReferencedBitmaps = append(clusterInfo.ReferencedBitmaps, bm)
 			}
 		}
+
+		if p.PerTrait {
+			var clusterGlobalEnums []*matter.Enum
+			for _, en := range globalEnums {
+				if _, ok := ceNames[en.Name]; ok {
+					if !slices.ContainsFunc(c.Enums, func(l *matter.Enum) bool { return l.Name == en.Name }) {
+						clusterGlobalEnums = append(clusterGlobalEnums, en)
+					}
+				}
+			}
+
+			var clusterGlobalBitmaps []*matter.Bitmap
+			for _, bm := range globalBitmaps {
+				if _, ok := ceNames[bm.Name]; ok {
+					if !slices.ContainsFunc(c.Bitmaps, func(l *matter.Bitmap) bool { return l.Name == bm.Name }) {
+						clusterGlobalBitmaps = append(clusterGlobalBitmaps, bm)
+					}
+				}
+			}
+
+			var clusterGlobalStructs []*matter.Struct
+			for _, s := range globalStructs {
+				if _, ok := ceNames[s.Name]; ok {
+					if !slices.ContainsFunc(c.Structs, func(l *matter.Struct) bool { return l.Name == s.Name }) {
+						clusterGlobalStructs = append(clusterGlobalStructs, s)
+					}
+				}
+			}
+
+			clusterTc := map[string]any{
+				"bitmaps":   clusterGlobalBitmaps,
+				"enums":     clusterGlobalEnums,
+				"structs":   clusterGlobalStructs,
+				"clusters":  []*ClusterInfo{clusterInfo},
+				"endpoints": nil,
+			}
+			var clusterOut string
+			clusterOut, err = t.Exec(clusterTc)
+			if err != nil {
+				slog.Error("error rendering matter template for cluster", slog.String("name", c.Name), slog.Any("err", err))
+				return
+			}
+			clusterFileName := getClusterFileName(c.Name)
+			clusterPath := filepath.Join(dir, clusterFileName)
+			outputs = append(outputs, pipeline.NewData(clusterPath, clusterOut))
+		}
+	}
+
+	if p.PerTrait {
+		return
 	}
 
 	tc := map[string]any{
@@ -435,141 +360,7 @@ func (p IdlRenderer) Process(cxt context.Context, input *pipeline.Data[*File], i
 		tc["endpoints"] = nil
 	}
 
-	var t *raymond.Template
-	t, err = p.loadTemplate(p.spec)
-	if err != nil {
-		return
-	}
 
-	if p.PerTrait {
-		for _, clusterInfo := range clusterList {
-			c := clusterInfo.Cluster
-			originalC := cloneToOriginal[c]
-			ce := clusterEntities[originalC]
-
-			ceNames := make(map[string]struct{}, len(ce))
-			for e := range ce {
-				ceNames[matter.EntityName(e)] = struct{}{}
-			}
-
-			var clusterGlobalEnums []*matter.Enum
-			var errata *errata.Errata
-			if doc, ok := p.spec.DocRefs[originalC]; ok && p.spec.Errata != nil {
-				errata = p.spec.Errata.Get(doc.Path.Relative)
-			}
-
-			var localEnums []*matter.Enum
-			for _, local := range c.Enums {
-				globalForced := false
-				if errata != nil && errata.SDK.Types != nil {
-					if entry, ok := errata.SDK.Types.Enums[local.Name]; ok && entry.ForceGlobal {
-						globalForced = true
-					}
-				}
-				if globalForced {
-					clusterGlobalEnums = append(clusterGlobalEnums, local)
-				} else {
-					localEnums = append(localEnums, local)
-				}
-			}
-			c.Enums = localEnums
-
-			for _, en := range globalEnums {
-				if _, ok := ceNames[en.Name]; ok {
-					isLocal := false
-					for _, local := range c.Enums {
-						if local.Name == en.Name {
-							isLocal = true
-							break
-						}
-					}
-					if !isLocal {
-						clusterGlobalEnums = append(clusterGlobalEnums, en)
-					}
-				}
-			}
-			var clusterGlobalBitmaps []*matter.Bitmap
-			var localBitmaps []*matter.Bitmap
-			for _, local := range c.Bitmaps {
-				globalForced := false
-				if errata != nil && errata.SDK.Types != nil {
-					if entry, ok := errata.SDK.Types.Bitmaps[local.Name]; ok && entry.ForceGlobal {
-						globalForced = true
-					}
-				}
-				if globalForced {
-					clusterGlobalBitmaps = append(clusterGlobalBitmaps, local)
-				} else {
-					localBitmaps = append(localBitmaps, local)
-				}
-			}
-			c.Bitmaps = localBitmaps
-			for _, bm := range globalBitmaps {
-				if _, ok := ceNames[bm.Name]; ok {
-					isLocal := false
-					for _, local := range c.Bitmaps {
-						if local.Name == bm.Name {
-							isLocal = true
-							break
-						}
-					}
-					if !isLocal {
-						clusterGlobalBitmaps = append(clusterGlobalBitmaps, bm)
-					}
-				}
-			}
-			var clusterGlobalStructs []*matter.Struct
-			var localStructs []*matter.Struct
-			for _, local := range c.Structs {
-				globalForced := false
-				if errata != nil && errata.SDK.Types != nil {
-					if entry, ok := errata.SDK.Types.Structs[local.Name]; ok && entry.ForceGlobal {
-						globalForced = true
-					}
-				}
-				if globalForced {
-					clusterGlobalStructs = append(clusterGlobalStructs, local)
-				} else {
-					localStructs = append(localStructs, local)
-				}
-			}
-			c.Structs = localStructs
-			for _, s := range globalStructs {
-				if _, ok := ceNames[s.Name]; ok {
-					isLocal := false
-					for _, local := range c.Structs {
-						if local.Name == s.Name {
-							isLocal = true
-							break
-						}
-					}
-					if !isLocal {
-						clusterGlobalStructs = append(clusterGlobalStructs, s)
-					}
-				}
-			}
-
-			clusterListSingle := []*ClusterInfo{clusterInfo}
-
-			clusterTc := map[string]any{
-				"bitmaps":   clusterGlobalBitmaps,
-				"enums":     clusterGlobalEnums,
-				"structs":   clusterGlobalStructs,
-				"clusters":  clusterListSingle,
-				"endpoints": nil,
-			}
-			var clusterOut string
-			clusterOut, err = t.Exec(clusterTc)
-			if err != nil {
-				slog.Error("error rendering matter template for cluster", slog.String("name", c.Name), slog.Any("err", err))
-				return
-			}
-			clusterFileName := getClusterFileName(c.Name)
-			clusterPath := filepath.Join(dir, clusterFileName)
-			outputs = append(outputs, pipeline.NewData(clusterPath, clusterOut))
-		}
-		return
-	}
 
 	var out string
 	out, err = t.Exec(tc)
@@ -662,58 +453,8 @@ func forceIncludeEntity(spec *spec.Specification, cluster *matter.Cluster, e typ
 
 func getClusterFileName(clusterName string) string {
 	name := caseify(clusterName, false, true)
-	name = idlNameToLowerSnakeCase(name)
+	name = text.ToIDLSnakeCase(name)
 	return name + ".matter"
-}
-
-func idlNameToLowerSnakeCase(text string) string {
-	replacer := strings.NewReplacer(
-		"BLE", "Ble",
-		"IDs", "Ids",
-		"IPv4", "Ipv4",
-		"IPv6", "Ipv6",
-		"iOS", "Ios",
-		"Int8U", "Int8u",
-		"KWh", "Kwh",
-		"KVAh", "Kvah",
-	)
-	text = replacer.Replace(text)
-
-	runes := []rune(text)
-	if len(runes) == 0 {
-		return ""
-	}
-
-	var splits []string
-	var current strings.Builder
-	current.WriteRune(runes[0])
-
-	for i := 1; i < len(runes); i++ {
-		shouldSplit := false
-		r := runes[i]
-		prev := runes[i-1]
-
-		if unicode.IsUpper(r) {
-			if !unicode.IsUpper(prev) {
-				shouldSplit = true
-			} else if i+1 < len(runes) && unicode.IsLower(runes[i+1]) {
-				shouldSplit = true
-			}
-		}
-
-		if shouldSplit {
-			splits = append(splits, current.String())
-			current.Reset()
-		}
-		current.WriteRune(r)
-	}
-	splits = append(splits, current.String())
-
-	for i, s := range splits {
-		splits[i] = strings.ToLower(s)
-	}
-
-	return strings.Join(splits, "_")
 }
 
 

--- a/idl/render.go
+++ b/idl/render.go
@@ -7,11 +7,13 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"unicode"
 
 	"github.com/mailgun/raymond/v2"
 	"github.com/project-chip/alchemy/asciidoc/parse"
 	"github.com/project-chip/alchemy/internal/handlebars"
 	"github.com/project-chip/alchemy/internal/pipeline"
+	"github.com/project-chip/alchemy/errata"
 	"github.com/project-chip/alchemy/matter"
 	"github.com/project-chip/alchemy/matter/conformance"
 	"github.com/project-chip/alchemy/matter/spec"
@@ -29,6 +31,7 @@ type IdlRenderer struct {
 
 	SuppressEndpoints   bool
 	SuppressProvisional string
+	PerTrait            bool
 
 	provisionalFilter ProvisionalFilter
 }
@@ -187,12 +190,81 @@ func (p IdlRenderer) Process(cxt context.Context, input *pipeline.Data[*File], i
 		}
 		if _, isGlobal := p.spec.GlobalObjects[entity]; isGlobal {
 			globalEntities[entity] = true
+			ce[entity] = struct{}{}
 			return parse.SearchShouldContinue
 		}
 		ce[entity] = struct{}{}
 		globalEntities[entity] = false
 		return parse.SearchShouldContinue
 	})
+
+	for c, ce := range clusterEntities {
+		doc, ok := p.spec.DocRefs[c]
+		if !ok {
+			continue
+		}
+		errata := p.spec.Errata.Get(doc.Path.Relative)
+		if errata == nil || errata.SDK.Types == nil {
+			continue
+		}
+		for name, entry := range errata.SDK.Types.Enums {
+			if entry.ForceLocal {
+				for entity := range globalEntities {
+					if en, ok := entity.(*matter.Enum); ok && en.Name == name {
+						exists := false
+						for _, existing := range c.Enums {
+							if existing.Name == name {
+								exists = true
+								break
+							}
+						}
+						if !exists {
+							ce[entity] = struct{}{}
+							c.Enums = append(c.Enums, en)
+						}
+					}
+				}
+			}
+		}
+		for name, entry := range errata.SDK.Types.Bitmaps {
+			if entry.ForceLocal {
+				for entity := range globalEntities {
+					if bm, ok := entity.(*matter.Bitmap); ok && bm.Name == name {
+						exists := false
+						for _, existing := range c.Bitmaps {
+							if existing.Name == name {
+								exists = true
+								break
+							}
+						}
+						if !exists {
+							ce[entity] = struct{}{}
+							c.Bitmaps = append(c.Bitmaps, bm)
+						}
+					}
+				}
+			}
+		}
+		for name, entry := range errata.SDK.Types.Structs {
+			if entry.ForceLocal {
+				for entity := range globalEntities {
+					if st, ok := entity.(*matter.Struct); ok && st.Name == name {
+						exists := false
+						for _, existing := range c.Structs {
+							if existing.Name == name {
+								exists = true
+								break
+							}
+						}
+						if !exists {
+							ce[entity] = struct{}{}
+							c.Structs = append(c.Structs, st)
+						}
+					}
+				}
+			}
+		}
+	}
 
 	for entity, isGlobal := range globalEntities {
 		if !isGlobal {
@@ -219,6 +291,15 @@ func (p IdlRenderer) Process(cxt context.Context, input *pipeline.Data[*File], i
 		if _, existing := namespaces[name]; !existing {
 			namespaces[name] = ns
 		}
+		doc, ok := p.spec.DocRefs[ns]
+		if ok {
+			errata := p.spec.Errata.Get(doc.Path.Relative)
+			if errata != nil && errata.SDK.Types != nil {
+				if entry, ok := errata.SDK.Types.Enums[name+"Tag"]; ok && entry.OverrideName != "" {
+					namespaces[entry.OverrideName] = ns
+				}
+			}
+		}
 	}
 
 	for fieldName, ns := range namespaces {
@@ -228,6 +309,15 @@ func (p IdlRenderer) Process(cxt context.Context, input *pipeline.Data[*File], i
 		} else {
 			en.Name = fieldName + "Tag"
 		}
+		doc, ok := p.spec.DocRefs[ns]
+		if ok {
+			errata := p.spec.Errata.Get(doc.Path.Relative)
+			if errata != nil && errata.SDK.Types != nil {
+				if entry, ok := errata.SDK.Types.Enums[en.Name]; ok && entry.OverrideName != "" {
+					en.Name = entry.OverrideName
+				}
+			}
+		}
 		en.Type = types.NewDataType(types.BaseDataTypeEnum8, types.DataTypeRankScalar)
 		for _, tag := range ns.SemanticTags {
 			nst := matter.NewEnumValue(tag.Source(), en)
@@ -236,6 +326,29 @@ func (p IdlRenderer) Process(cxt context.Context, input *pipeline.Data[*File], i
 			en.Values = append(en.Values, nst)
 		}
 		globalEnums = append(globalEnums, en)
+		for c, ce := range clusterEntities {
+			doc, ok := p.spec.DocRefs[c]
+			if !ok {
+				continue
+			}
+			errata := p.spec.Errata.Get(doc.Path.Relative)
+			if errata == nil || errata.SDK.Types == nil {
+				continue
+			}
+			if entry, ok := errata.SDK.Types.Enums[en.Name]; ok && entry.Keep {
+				exists := false
+				for _, existing := range c.Enums {
+					if existing.Name == en.Name {
+						exists = true
+						break
+					}
+				}
+				if !exists {
+					ce[en] = struct{}{}
+					c.Enums = append(c.Enums, en)
+				}
+			}
+		}
 	}
 
 	slices.SortFunc(globalEnums, func(a, b *matter.Enum) int {
@@ -255,22 +368,43 @@ func (p IdlRenderer) Process(cxt context.Context, input *pipeline.Data[*File], i
 		if !ok {
 			continue
 		}
+
+		var errata *errata.Errata
+		if doc, ok := p.spec.DocRefs[clusterInfo.Cluster]; ok && p.spec.Errata != nil {
+			errata = p.spec.Errata.Get(doc.Path.Relative)
+		}
+
 		ceNames := make(map[string]struct{}, len(ce))
 		for e := range ce {
 			ceNames[matter.EntityName(e)] = struct{}{}
 		}
 		for _, s := range clusterInfo.Cluster.Structs {
 			if _, ok := ceNames[s.Name]; ok {
+				if errata != nil && errata.SDK.Types != nil {
+					if entry, ok := errata.SDK.Types.Structs[s.Name]; ok && entry.ForceGlobal {
+						continue
+					}
+				}
 				clusterInfo.ReferencedStructs = append(clusterInfo.ReferencedStructs, s)
 			}
 		}
 		for _, en := range clusterInfo.Cluster.Enums {
 			if _, ok := ceNames[en.Name]; ok {
+				if errata != nil && errata.SDK.Types != nil {
+					if entry, ok := errata.SDK.Types.Enums[en.Name]; ok && entry.ForceGlobal {
+						continue
+					}
+				}
 				clusterInfo.ReferencedEnums = append(clusterInfo.ReferencedEnums, en)
 			}
 		}
 		for _, bm := range clusterInfo.Cluster.Bitmaps {
 			if _, ok := ceNames[bm.Name]; ok {
+				if errata != nil && errata.SDK.Types != nil {
+					if entry, ok := errata.SDK.Types.Bitmaps[bm.Name]; ok && entry.ForceGlobal {
+						continue
+					}
+				}
 				clusterInfo.ReferencedBitmaps = append(clusterInfo.ReferencedBitmaps, bm)
 			}
 		}
@@ -290,6 +424,135 @@ func (p IdlRenderer) Process(cxt context.Context, input *pipeline.Data[*File], i
 	var t *raymond.Template
 	t, err = p.loadTemplate(p.spec)
 	if err != nil {
+		return
+	}
+
+	if p.PerTrait {
+		for _, clusterInfo := range clusterList {
+			c := clusterInfo.Cluster
+			ce := clusterEntities[c]
+
+			ceNames := make(map[string]struct{}, len(ce))
+			for e := range ce {
+				ceNames[matter.EntityName(e)] = struct{}{}
+			}
+
+			var clusterGlobalEnums []*matter.Enum
+			var errata *errata.Errata
+			if doc, ok := p.spec.DocRefs[c]; ok && p.spec.Errata != nil {
+				errata = p.spec.Errata.Get(doc.Path.Relative)
+			}
+
+			for i := 0; i < len(c.Enums); {
+				local := c.Enums[i]
+				globalForced := false
+				if errata != nil && errata.SDK.Types != nil {
+					if entry, ok := errata.SDK.Types.Enums[local.Name]; ok && entry.ForceGlobal {
+						globalForced = true
+					}
+				}
+				if globalForced {
+					clusterGlobalEnums = append(clusterGlobalEnums, local)
+					c.Enums = append(c.Enums[:i], c.Enums[i+1:]...)
+				} else {
+					i++
+				}
+			}
+
+			for _, en := range globalEnums {
+				if _, ok := ceNames[en.Name]; ok {
+					isLocal := false
+					for _, local := range c.Enums {
+						if local.Name == en.Name {
+							isLocal = true
+							break
+						}
+					}
+					if !isLocal {
+						clusterGlobalEnums = append(clusterGlobalEnums, en)
+					}
+				}
+			}
+			var clusterGlobalBitmaps []*matter.Bitmap
+			for i := 0; i < len(c.Bitmaps); {
+				local := c.Bitmaps[i]
+				globalForced := false
+				if errata != nil && errata.SDK.Types != nil {
+					if entry, ok := errata.SDK.Types.Bitmaps[local.Name]; ok && entry.ForceGlobal {
+						globalForced = true
+					}
+				}
+				if globalForced {
+					clusterGlobalBitmaps = append(clusterGlobalBitmaps, local)
+					c.Bitmaps = append(c.Bitmaps[:i], c.Bitmaps[i+1:]...)
+				} else {
+					i++
+				}
+			}
+			for _, bm := range globalBitmaps {
+				if _, ok := ceNames[bm.Name]; ok {
+					isLocal := false
+					for _, local := range c.Bitmaps {
+						if local.Name == bm.Name {
+							isLocal = true
+							break
+						}
+					}
+					if !isLocal {
+						clusterGlobalBitmaps = append(clusterGlobalBitmaps, bm)
+					}
+				}
+			}
+			var clusterGlobalStructs []*matter.Struct
+			for i := 0; i < len(c.Structs); {
+				local := c.Structs[i]
+				globalForced := false
+				if errata != nil && errata.SDK.Types != nil {
+					if entry, ok := errata.SDK.Types.Structs[local.Name]; ok && entry.ForceGlobal {
+						globalForced = true
+					}
+				}
+				if globalForced {
+					clusterGlobalStructs = append(clusterGlobalStructs, local)
+					c.Structs = append(c.Structs[:i], c.Structs[i+1:]...)
+				} else {
+					i++
+				}
+			}
+			for _, s := range globalStructs {
+				if _, ok := ceNames[s.Name]; ok {
+					isLocal := false
+					for _, local := range c.Structs {
+						if local.Name == s.Name {
+							isLocal = true
+							break
+						}
+					}
+					if !isLocal {
+						clusterGlobalStructs = append(clusterGlobalStructs, s)
+					}
+				}
+			}
+
+			clusterListSingle := []*ClusterInfo{clusterInfo}
+
+			clusterTc := map[string]any{
+				"bitmaps":   clusterGlobalBitmaps,
+				"enums":     clusterGlobalEnums,
+				"structs":   clusterGlobalStructs,
+				"clusters":  clusterListSingle,
+				"endpoints": nil,
+			}
+			var clusterOut string
+			clusterOut, err = t.Exec(clusterTc)
+			if err != nil {
+				slog.Error("error rendering matter template for cluster", slog.String("name", c.Name), slog.Any("err", err))
+				return
+			}
+			clusterFileName := getClusterFileName(c.Name)
+			clusterPath := filepath.Join(dir, clusterFileName)
+			outputs = append(outputs, pipeline.NewData(clusterPath, clusterOut))
+		}
 		return
 	}
 
@@ -341,24 +604,104 @@ func forceIncludeEntity(spec *spec.Specification, cluster *matter.Cluster, e typ
 		return false
 	}
 	errata := spec.Errata.Get(doc.Path.Relative)
-	if errata == nil || errata.SDK.ExtraTypes == nil {
+	if errata == nil || (errata.SDK.ExtraTypes == nil && errata.SDK.Types == nil) {
 		return false
 	}
 	switch e := e.(type) {
 	case *matter.Bitmap:
-		if _, ok := errata.SDK.ExtraTypes.Bitmaps[e.Name]; ok {
-			return true
+		if errata.SDK.ExtraTypes != nil {
+			if _, ok := errata.SDK.ExtraTypes.Bitmaps[e.Name]; ok {
+				return true
+			}
+		}
+		if errata.SDK.Types != nil {
+			if entry, ok := errata.SDK.Types.Bitmaps[e.Name]; ok && entry.Keep {
+				return true
+			}
 		}
 	case *matter.Enum:
-		if _, ok := errata.SDK.ExtraTypes.Enums[e.Name]; ok {
-			return true
+		if errata.SDK.ExtraTypes != nil {
+			if _, ok := errata.SDK.ExtraTypes.Enums[e.Name]; ok {
+				return true
+			}
+		}
+		if errata.SDK.Types != nil {
+			if entry, ok := errata.SDK.Types.Enums[e.Name]; ok && entry.Keep {
+				return true
+			}
 		}
 	case *matter.Struct:
-		if _, ok := errata.SDK.ExtraTypes.Structs[e.Name]; ok {
-			return true
+		if errata.SDK.ExtraTypes != nil {
+			if _, ok := errata.SDK.ExtraTypes.Structs[e.Name]; ok {
+				return true
+			}
+		}
+		if errata.SDK.Types != nil {
+			if entry, ok := errata.SDK.Types.Structs[e.Name]; ok && entry.Keep {
+				return true
+			}
 		}
 	}
 	return false
+}
+
+func getClusterFileName(clusterName string) string {
+	name := caseify(clusterName, false, true)
+	name = idlNameToLowerSnakeCase(name)
+	return name + ".matter"
+}
+
+func idlNameToLowerSnakeCase(text string) string {
+	replaceTerms := map[string]string{
+		"BLE":   "Ble",
+		"IDs":   "Ids",
+		"IPv4":  "Ipv4",
+		"IPv6":  "Ipv6",
+		"iOS":   "Ios",
+		"Int8U": "Int8u",
+		"KWh":   "Kwh",
+		"KVAh":  "Kvah",
+	}
+
+	for old, new := range replaceTerms {
+		text = strings.ReplaceAll(text, old, new)
+	}
+
+	runes := []rune(text)
+	if len(runes) == 0 {
+		return ""
+	}
+
+	var splits []string
+	var current strings.Builder
+	current.WriteRune(runes[0])
+
+	for i := 1; i < len(runes); i++ {
+		shouldSplit := false
+		r := runes[i]
+		prev := runes[i-1]
+
+		if unicode.IsUpper(r) {
+			if !unicode.IsUpper(prev) {
+				shouldSplit = true
+			} else if i+1 < len(runes) && unicode.IsLower(runes[i+1]) {
+				shouldSplit = true
+			}
+		}
+
+		if shouldSplit {
+			splits = append(splits, current.String())
+			current.Reset()
+		}
+		current.WriteRune(r)
+	}
+	splits = append(splits, current.String())
+
+	for i, s := range splits {
+		splits[i] = strings.ToLower(s)
+	}
+
+	return strings.Join(splits, "_")
 }
 
 

--- a/idl/render.go
+++ b/idl/render.go
@@ -95,14 +95,6 @@ func (p IdlRenderer) Process(cxt context.Context, input *pipeline.Data[*File], i
 	filter := ProvisionalFilter{
 		Mode: p.SuppressProvisional,
 	}
-	if p.SuppressProvisional == "keep-existing" {
-		elements, err := parseExistingMatterElements(path)
-		if err != nil {
-			slog.Warn("Failed to parse existing matter file for provisional elements", slog.String("path", path), slog.Any("err", err))
-		} else {
-			filter.ExistingElements = elements
-		}
-	}
 	p.provisionalFilter = filter
 
 	var endpoints []Endpoint

--- a/idl/render.go
+++ b/idl/render.go
@@ -248,6 +248,16 @@ func (p IdlRenderer) Process(cxt context.Context, input *pipeline.Data[*File], i
 			en.Values = append(en.Values, nst)
 		}
 		globalEnums = append(globalEnums, en)
+		for _, clusterInfo := range clusterList {
+			c := clusterInfo.Cluster
+			ce, ok := clusterEntities[c]
+			if !ok {
+				continue
+			}
+			if _, ok := ce[ns]; ok {
+				ce[en] = struct{}{}
+			}
+		}
 	}
 
 	slices.SortFunc(globalEnums, func(a, b *matter.Enum) int {
@@ -275,22 +285,18 @@ func (p IdlRenderer) Process(cxt context.Context, input *pipeline.Data[*File], i
 			continue
 		}
 
-		ceNames := make(map[string]struct{}, len(ce))
-		for e := range ce {
-			ceNames[matter.EntityName(e)] = struct{}{}
-		}
 		for _, s := range clusterInfo.Cluster.Structs {
-			if _, ok := ceNames[s.Name]; ok {
+			if _, ok := ce[s]; ok {
 				clusterInfo.ReferencedStructs = append(clusterInfo.ReferencedStructs, s)
 			}
 		}
 		for _, en := range clusterInfo.Cluster.Enums {
-			if _, ok := ceNames[en.Name]; ok {
+			if _, ok := ce[en]; ok {
 				clusterInfo.ReferencedEnums = append(clusterInfo.ReferencedEnums, en)
 			}
 		}
 		for _, bm := range clusterInfo.Cluster.Bitmaps {
-			if _, ok := ceNames[bm.Name]; ok {
+			if _, ok := ce[bm]; ok {
 				clusterInfo.ReferencedBitmaps = append(clusterInfo.ReferencedBitmaps, bm)
 			}
 		}
@@ -298,7 +304,7 @@ func (p IdlRenderer) Process(cxt context.Context, input *pipeline.Data[*File], i
 		if p.PerTrait {
 			var clusterGlobalEnums []*matter.Enum
 			for _, en := range globalEnums {
-				if _, ok := ceNames[en.Name]; ok {
+				if _, ok := ce[en]; ok {
 					if !slices.ContainsFunc(c.Enums, func(l *matter.Enum) bool { return l.Name == en.Name }) {
 						clusterGlobalEnums = append(clusterGlobalEnums, en)
 					}
@@ -307,7 +313,7 @@ func (p IdlRenderer) Process(cxt context.Context, input *pipeline.Data[*File], i
 
 			var clusterGlobalBitmaps []*matter.Bitmap
 			for _, bm := range globalBitmaps {
-				if _, ok := ceNames[bm.Name]; ok {
+				if _, ok := ce[bm]; ok {
 					if !slices.ContainsFunc(c.Bitmaps, func(l *matter.Bitmap) bool { return l.Name == bm.Name }) {
 						clusterGlobalBitmaps = append(clusterGlobalBitmaps, bm)
 					}
@@ -316,7 +322,7 @@ func (p IdlRenderer) Process(cxt context.Context, input *pipeline.Data[*File], i
 
 			var clusterGlobalStructs []*matter.Struct
 			for _, s := range globalStructs {
-				if _, ok := ceNames[s.Name]; ok {
+				if _, ok := ce[s]; ok {
 					if !slices.ContainsFunc(c.Structs, func(l *matter.Struct) bool { return l.Name == s.Name }) {
 						clusterGlobalStructs = append(clusterGlobalStructs, s)
 					}

--- a/idl/render.go
+++ b/idl/render.go
@@ -190,9 +190,26 @@ func (p IdlRenderer) Process(cxt context.Context, input *pipeline.Data[*File], i
 		return parse.SearchShouldContinue
 	})
 
-	for c, ce := range clusterEntities {
-		doc, ok := p.spec.DocRefs[c]
+	originalToClone := make(map[*matter.Cluster]*matter.Cluster)
+	cloneToOriginal := make(map[*matter.Cluster]*matter.Cluster)
+	for _, ci := range clusterList {
+		originalC := ci.Cluster
+		cClone := *originalC
+		cClone.Enums = slices.Clone(cClone.Enums)
+		cClone.Bitmaps = slices.Clone(cClone.Bitmaps)
+		cClone.Structs = slices.Clone(cClone.Structs)
+		ci.Cluster = &cClone
+		originalToClone[originalC] = &cClone
+		cloneToOriginal[&cClone] = originalC
+	}
+
+	for originalC, ce := range clusterEntities {
+		c := originalToClone[originalC]
+		doc, ok := p.spec.DocRefs[originalC]
 		if !ok {
+			continue
+		}
+		if p.spec.Errata == nil {
 			continue
 		}
 		errata := p.spec.Errata.Get(doc.Path.Relative)
@@ -284,7 +301,7 @@ func (p IdlRenderer) Process(cxt context.Context, input *pipeline.Data[*File], i
 			namespaces[name] = ns
 		}
 		doc, ok := p.spec.DocRefs[ns]
-		if ok {
+		if ok && p.spec.Errata != nil {
 			errata := p.spec.Errata.Get(doc.Path.Relative)
 			if errata != nil && errata.SDK.Types != nil {
 				if entry, ok := errata.SDK.Types.Enums[name+"Tag"]; ok && entry.OverrideName != "" {
@@ -302,7 +319,7 @@ func (p IdlRenderer) Process(cxt context.Context, input *pipeline.Data[*File], i
 			en.Name = fieldName + "Tag"
 		}
 		doc, ok := p.spec.DocRefs[ns]
-		if ok {
+		if ok && p.spec.Errata != nil {
 			errata := p.spec.Errata.Get(doc.Path.Relative)
 			if errata != nil && errata.SDK.Types != nil {
 				if entry, ok := errata.SDK.Types.Enums[en.Name]; ok && entry.OverrideName != "" {
@@ -318,9 +335,13 @@ func (p IdlRenderer) Process(cxt context.Context, input *pipeline.Data[*File], i
 			en.Values = append(en.Values, nst)
 		}
 		globalEnums = append(globalEnums, en)
-		for c, ce := range clusterEntities {
-			doc, ok := p.spec.DocRefs[c]
+		for originalC, ce := range clusterEntities {
+			c := originalToClone[originalC]
+			doc, ok := p.spec.DocRefs[originalC]
 			if !ok {
+				continue
+			}
+			if p.spec.Errata == nil {
 				continue
 			}
 			errata := p.spec.Errata.Get(doc.Path.Relative)
@@ -356,13 +377,14 @@ func (p IdlRenderer) Process(cxt context.Context, input *pipeline.Data[*File], i
 	})
 
 	for _, clusterInfo := range clusterList {
-		ce, ok := clusterEntities[clusterInfo.Cluster]
+		originalC := cloneToOriginal[clusterInfo.Cluster]
+		ce, ok := clusterEntities[originalC]
 		if !ok {
 			continue
 		}
 
 		var errata *errata.Errata
-		if doc, ok := p.spec.DocRefs[clusterInfo.Cluster]; ok && p.spec.Errata != nil {
+		if doc, ok := p.spec.DocRefs[originalC]; ok && p.spec.Errata != nil {
 			errata = p.spec.Errata.Get(doc.Path.Relative)
 		}
 
@@ -422,7 +444,8 @@ func (p IdlRenderer) Process(cxt context.Context, input *pipeline.Data[*File], i
 	if p.PerTrait {
 		for _, clusterInfo := range clusterList {
 			c := clusterInfo.Cluster
-			ce := clusterEntities[c]
+			originalC := cloneToOriginal[c]
+			ce := clusterEntities[originalC]
 
 			ceNames := make(map[string]struct{}, len(ce))
 			for e := range ce {
@@ -431,12 +454,12 @@ func (p IdlRenderer) Process(cxt context.Context, input *pipeline.Data[*File], i
 
 			var clusterGlobalEnums []*matter.Enum
 			var errata *errata.Errata
-			if doc, ok := p.spec.DocRefs[c]; ok && p.spec.Errata != nil {
+			if doc, ok := p.spec.DocRefs[originalC]; ok && p.spec.Errata != nil {
 				errata = p.spec.Errata.Get(doc.Path.Relative)
 			}
 
-			for i := 0; i < len(c.Enums); {
-				local := c.Enums[i]
+			var localEnums []*matter.Enum
+			for _, local := range c.Enums {
 				globalForced := false
 				if errata != nil && errata.SDK.Types != nil {
 					if entry, ok := errata.SDK.Types.Enums[local.Name]; ok && entry.ForceGlobal {
@@ -445,11 +468,11 @@ func (p IdlRenderer) Process(cxt context.Context, input *pipeline.Data[*File], i
 				}
 				if globalForced {
 					clusterGlobalEnums = append(clusterGlobalEnums, local)
-					c.Enums = append(c.Enums[:i], c.Enums[i+1:]...)
 				} else {
-					i++
+					localEnums = append(localEnums, local)
 				}
 			}
+			c.Enums = localEnums
 
 			for _, en := range globalEnums {
 				if _, ok := ceNames[en.Name]; ok {
@@ -466,8 +489,8 @@ func (p IdlRenderer) Process(cxt context.Context, input *pipeline.Data[*File], i
 				}
 			}
 			var clusterGlobalBitmaps []*matter.Bitmap
-			for i := 0; i < len(c.Bitmaps); {
-				local := c.Bitmaps[i]
+			var localBitmaps []*matter.Bitmap
+			for _, local := range c.Bitmaps {
 				globalForced := false
 				if errata != nil && errata.SDK.Types != nil {
 					if entry, ok := errata.SDK.Types.Bitmaps[local.Name]; ok && entry.ForceGlobal {
@@ -476,11 +499,11 @@ func (p IdlRenderer) Process(cxt context.Context, input *pipeline.Data[*File], i
 				}
 				if globalForced {
 					clusterGlobalBitmaps = append(clusterGlobalBitmaps, local)
-					c.Bitmaps = append(c.Bitmaps[:i], c.Bitmaps[i+1:]...)
 				} else {
-					i++
+					localBitmaps = append(localBitmaps, local)
 				}
 			}
+			c.Bitmaps = localBitmaps
 			for _, bm := range globalBitmaps {
 				if _, ok := ceNames[bm.Name]; ok {
 					isLocal := false
@@ -496,8 +519,8 @@ func (p IdlRenderer) Process(cxt context.Context, input *pipeline.Data[*File], i
 				}
 			}
 			var clusterGlobalStructs []*matter.Struct
-			for i := 0; i < len(c.Structs); {
-				local := c.Structs[i]
+			var localStructs []*matter.Struct
+			for _, local := range c.Structs {
 				globalForced := false
 				if errata != nil && errata.SDK.Types != nil {
 					if entry, ok := errata.SDK.Types.Structs[local.Name]; ok && entry.ForceGlobal {
@@ -506,11 +529,11 @@ func (p IdlRenderer) Process(cxt context.Context, input *pipeline.Data[*File], i
 				}
 				if globalForced {
 					clusterGlobalStructs = append(clusterGlobalStructs, local)
-					c.Structs = append(c.Structs[:i], c.Structs[i+1:]...)
 				} else {
-					i++
+					localStructs = append(localStructs, local)
 				}
 			}
+			c.Structs = localStructs
 			for _, s := range globalStructs {
 				if _, ok := ceNames[s.Name]; ok {
 					isLocal := false
@@ -644,20 +667,17 @@ func getClusterFileName(clusterName string) string {
 }
 
 func idlNameToLowerSnakeCase(text string) string {
-	replaceTerms := map[string]string{
-		"BLE":   "Ble",
-		"IDs":   "Ids",
-		"IPv4":  "Ipv4",
-		"IPv6":  "Ipv6",
-		"iOS":   "Ios",
-		"Int8U": "Int8u",
-		"KWh":   "Kwh",
-		"KVAh":  "Kvah",
-	}
-
-	for old, new := range replaceTerms {
-		text = strings.ReplaceAll(text, old, new)
-	}
+	replacer := strings.NewReplacer(
+		"BLE", "Ble",
+		"IDs", "Ids",
+		"IPv4", "Ipv4",
+		"IPv6", "Ipv6",
+		"iOS", "Ios",
+		"Int8U", "Int8u",
+		"KWh", "Kwh",
+		"KVAh", "Kvah",
+	)
+	text = replacer.Replace(text)
 
 	runes := []rune(text)
 	if len(runes) == 0 {

--- a/idl/render_test.go
+++ b/idl/render_test.go
@@ -457,3 +457,26 @@ provisional cluster ProvCluster = 2 {
 		t.Errorf("expected ProvCluster2 to be suppressed in keep output: %s", contentKeep)
 	}
 }
+
+func TestGetClusterFileName(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"On/Off", "on_off.matter"},
+		{"PM10 Concentration Measurement", "pm10_concentration_measurement.matter"},
+		{"PM1 Concentration Measurement", "pm1_concentration_measurement.matter"},
+		{"PM2.5 Concentration Measurement", "pm25_concentration_measurement.matter"},
+		{"Door Lock", "door_lock.matter"},
+		{"Thermostat", "thermostat.matter"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := getClusterFileName(tt.input)
+			if got != tt.want {
+				t.Errorf("getClusterFileName(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/idl/render_test.go
+++ b/idl/render_test.go
@@ -2,8 +2,6 @@ package idl
 
 import (
 	"context"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -49,24 +47,6 @@ func TestEntityShouldBeIncluded(t *testing.T) {
 		t.Errorf("expected non-provisional field to be included with Mode=all")
 	}
 
-	// 3. Test Mode = "keep-existing"
-	filterKeepExisting := ProvisionalFilter{
-		Mode: "keep-existing",
-		ExistingElements: map[string]bool{
-			"provfield": true, // Normalize to lowercase for case-insensitive lookup
-		},
-	}
-	if !entityShouldBeIncluded(specification, filterKeepExisting, provField) {
-		t.Errorf("expected provisional field to be included because it is present in ExistingElements")
-	}
-
-	filterKeepExistingEmpty := ProvisionalFilter{
-		Mode:             "keep-existing",
-		ExistingElements: map[string]bool{},
-	}
-	if entityShouldBeIncluded(specification, filterKeepExistingEmpty, provField) {
-		t.Errorf("expected provisional field to be excluded because it is NOT present in ExistingElements")
-	}
 }
 
 func TestSuppressProvisionalIntegration(t *testing.T) {
@@ -380,81 +360,6 @@ func TestSuppressProvisionalIntegration(t *testing.T) {
 	}
 	if strings.Contains(contentAll, "optional event ProvEvt") || !strings.Contains(contentAll, "event NonProvEvt") {
 		t.Errorf("expected events in all output (ProvEvt suppressed, NonProvEvt kept): %s", contentAll)
-	}
-
-	// 4. Test Case C: --suppress-provisional keep-existing
-	tmpDir, err := os.MkdirTemp("", "matter-test-keep-*")
-	if err != nil {
-		t.Fatalf("failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
-
-	// Let's create an existing file that has some of the provisional elements, e.g. ProvAttrEnum, ProvAttrStruct, ProvAttrBitmap, ProvCmd, ProvEnum, ProvStruct, ProvBitmap,
-	// but does NOT have ProvEvt.
-	existingFileContent := `
-cluster MyCluster = 1 {
-  enum ProvEnum : enum8 {}
-  struct ProvStruct {}
-  bitmap ProvBitmap : bitmap8 {
-    kMyBit = 0x1;
-  }
-  provisional readonly attribute ProvEnum provAttrEnum = 1;
-  provisional readonly attribute ProvStruct provAttrStruct = 2;
-  provisional readonly attribute ProvBitmap provAttrBitmap = 3;
-  provisional command ProvCmd() = 1;
-}
-provisional cluster ProvCluster = 2 {
-}
-`
-	existingPath := filepath.Join(tmpDir, "existing.matter")
-	err = os.WriteFile(existingPath, []byte(existingFileContent), 0644)
-	if err != nil {
-		t.Fatalf("failed to write existing file: %v", err)
-	}
-
-	// We pass existingPath as the output destination (so the renderer reads existingPath to parse the present elements)
-	inputKeep := pipeline.NewData(existingPath, syntheticFile)
-	rendererKeep, err := NewIdlRenderer(specification)
-	if err != nil {
-		t.Fatalf("failed to create renderer: %v", err)
-	}
-	rendererKeep.SuppressProvisional = "keep-existing"
-
-	outputsKeep, _, err := rendererKeep.Process(ctx, inputKeep, 0, 1)
-	if err != nil {
-		t.Fatalf("Process failed: %v", err)
-	}
-	contentKeep := outputsKeep[0].Content
-	// Check that elements present in existing file are KEPT, while ProvEvt (not in existing file) is SUPPRESSED
-	if !strings.Contains(contentKeep, "enum ProvEnum") || !strings.Contains(contentKeep, "enum NonProvEnum") {
-		t.Errorf("expected enums in keep output: %s", contentKeep)
-	}
-	if !strings.Contains(contentKeep, "struct ProvStruct") || !strings.Contains(contentKeep, "struct NonProvStruct") {
-		t.Errorf("expected structs in keep output: %s", contentKeep)
-	}
-	if !strings.Contains(contentKeep, "bitmap ProvBitmap") || !strings.Contains(contentKeep, "bitmap NonProvBitmap") {
-		t.Errorf("expected bitmaps in keep output: %s", contentKeep)
-	}
-	if !strings.Contains(contentKeep, "provAttrEnum") || !strings.Contains(contentKeep, "nonProvAttrEnum") {
-		t.Errorf("expected attributes in keep output: %s", contentKeep)
-	}
-	if !strings.Contains(contentKeep, "struct ProvCmd") || !strings.Contains(contentKeep, "struct NonProvCmd") {
-		t.Errorf("expected commands in keep output: %s", contentKeep)
-	}
-	// ProvEvt was NOT in existing file, so it MUST be suppressed!
-	if strings.Contains(contentKeep, "optional event ProvEvt") {
-		t.Errorf("expected ProvEvt to be suppressed in keep output: %s", contentKeep)
-	}
-	if !strings.Contains(contentKeep, "event NonProvEvt") {
-		t.Errorf("expected NonProvEvt to be kept in keep output: %s", contentKeep)
-	}
-	// ProvCluster was in existing file, so it MUST be kept!
-	if !strings.Contains(contentKeep, "cluster ProvCluster") {
-		t.Errorf("expected ProvCluster to be kept in keep output: %s", contentKeep)
-	}
-	// ProvCluster2 was NOT in existing file, so it MUST be suppressed!
-	if strings.Contains(contentKeep, "cluster ProvCluster2") {
-		t.Errorf("expected ProvCluster2 to be suppressed in keep output: %s", contentKeep)
 	}
 }
 

--- a/idl/templates/matter.handlebars
+++ b/idl/templates/matter.handlebars
@@ -1,24 +1,19 @@
 // This IDL was generated automatically by Alchemy.
+// Do not modify manually.
+// Refer to README.md for more details.
 
 {{#enums enums}}
-
 {{> enum enum=this shared=shared provisional=@provisional}}
 {{/enums}}
 {{#bitmaps bitmaps}}
-
 {{> bitmap bitmap=this shared=shared provisional=@provisional}}
 {{/bitmaps}}
 {{#structs structs}}
-
 {{> struct struct=this shared=shared provisional=@provisional}}
 {{/structs}}
 {{#clusters clusters}}
-
 {{> cluster clusterInfo=this  provisional=@provisional}}
 {{/clusters}}
-
 {{#each endpoints}}
 {{> endpoint endpoint=this  provisional=@provisional}}
 {{/each}}
-
-

--- a/internal/text/case.go
+++ b/internal/text/case.go
@@ -1,0 +1,58 @@
+package text
+
+import (
+	"strings"
+	"unicode"
+)
+
+// ToIDLSnakeCase converts a string, typically CamelCase or PascalCase, to snake_case.
+// It includes custom replacements to handle acronyms commonly found in Matter.
+func ToIDLSnakeCase(text string) string {
+	replacer := strings.NewReplacer(
+		"BLE", "Ble",
+		"IDs", "Ids",
+		"IPv4", "Ipv4",
+		"IPv6", "Ipv6",
+		"iOS", "Ios",
+		"Int8U", "Int8u",
+		"KWh", "Kwh",
+		"KVAh", "Kvah",
+	)
+	text = replacer.Replace(text)
+
+	runes := []rune(text)
+	if len(runes) == 0 {
+		return ""
+	}
+
+	var splits []string
+	var current strings.Builder
+	current.WriteRune(runes[0])
+
+	for i := 1; i < len(runes); i++ {
+		shouldSplit := false
+		r := runes[i]
+		prev := runes[i-1]
+
+		if unicode.IsUpper(r) {
+			if !unicode.IsUpper(prev) {
+				shouldSplit = true
+			} else if i+1 < len(runes) && unicode.IsLower(runes[i+1]) {
+				shouldSplit = true
+			}
+		}
+
+		if shouldSplit {
+			splits = append(splits, current.String())
+			current.Reset()
+		}
+		current.WriteRune(r)
+	}
+	splits = append(splits, current.String())
+
+	for i, s := range splits {
+		splits[i] = strings.ToLower(s)
+	}
+
+	return strings.Join(splits, "_")
+}

--- a/matter/spec/errata_apply.go
+++ b/matter/spec/errata_apply.go
@@ -1,0 +1,121 @@
+package spec
+
+import (
+	"github.com/project-chip/alchemy/matter"
+)
+
+func applySdkErrata(spec *Specification) {
+	globalEnums := make(map[string]*matter.Enum)
+	globalBitmaps := make(map[string]*matter.Bitmap)
+	globalStructs := make(map[string]*matter.Struct)
+
+	for entity := range spec.GlobalObjects {
+		switch e := entity.(type) {
+		case *matter.Enum:
+			globalEnums[e.Name] = e
+		case *matter.Bitmap:
+			globalBitmaps[e.Name] = e
+		case *matter.Struct:
+			globalStructs[e.Name] = e
+		}
+	}
+
+	for originalC := range spec.Clusters {
+		doc, ok := spec.DocRefs[originalC]
+		if !ok || spec.Errata == nil {
+			continue
+		}
+		errata := spec.Errata.Get(doc.Path.Relative)
+		if errata == nil || errata.SDK.Types == nil {
+			continue
+		}
+
+		// Process ForceLocal / Keep
+		for name, entry := range errata.SDK.Types.Enums {
+			if entry.ForceLocal || entry.Keep {
+				if en, ok := globalEnums[name]; ok {
+					exists := false
+					for _, existing := range originalC.Enums {
+						if existing.Name == name {
+							exists = true
+							break
+						}
+					}
+					if !exists {
+						originalC.Enums = append(originalC.Enums, en)
+					}
+				}
+			}
+		}
+		for name, entry := range errata.SDK.Types.Bitmaps {
+			if entry.ForceLocal || entry.Keep {
+				if bm, ok := globalBitmaps[name]; ok {
+					exists := false
+					for _, existing := range originalC.Bitmaps {
+						if existing.Name == name {
+							exists = true
+							break
+						}
+					}
+					if !exists {
+						originalC.Bitmaps = append(originalC.Bitmaps, bm)
+					}
+				}
+			}
+		}
+		for name, entry := range errata.SDK.Types.Structs {
+			if entry.ForceLocal || entry.Keep {
+				if st, ok := globalStructs[name]; ok {
+					exists := false
+					for _, existing := range originalC.Structs {
+						if existing.Name == name {
+							exists = true
+							break
+						}
+					}
+					if !exists {
+						originalC.Structs = append(originalC.Structs, st)
+					}
+				}
+			}
+		}
+
+		// Process ForceGlobal
+		for name, entry := range errata.SDK.Types.Enums {
+			if entry.ForceGlobal {
+				for i, existing := range originalC.Enums {
+					if existing.Name == name {
+						originalC.Enums = append(originalC.Enums[:i], originalC.Enums[i+1:]...)
+						spec.addEntityByName(name, existing, nil)
+						spec.GlobalObjects[existing] = doc
+						break
+					}
+				}
+			}
+		}
+		for name, entry := range errata.SDK.Types.Bitmaps {
+			if entry.ForceGlobal {
+				for i, existing := range originalC.Bitmaps {
+					if existing.Name == name {
+						originalC.Bitmaps = append(originalC.Bitmaps[:i], originalC.Bitmaps[i+1:]...)
+						spec.addEntityByName(name, existing, nil)
+						spec.GlobalObjects[existing] = doc
+						break
+					}
+				}
+			}
+		}
+		for name, entry := range errata.SDK.Types.Structs {
+			if entry.ForceGlobal {
+				for i, existing := range originalC.Structs {
+					if existing.Name == name {
+						originalC.Structs = append(originalC.Structs[:i], originalC.Structs[i+1:]...)
+						spec.addEntityByName(name, existing, nil)
+						spec.GlobalObjects[existing] = doc
+						break
+					}
+				}
+			}
+		}
+	}
+}

--- a/matter/spec/patch.go
+++ b/matter/spec/patch.go
@@ -17,6 +17,7 @@ func patchSpecForSdk(spec *Specification) error {
 	patchLabelCluster(spec)
 	patchLevelControlCluster(spec)
 	patchContentLaunchCluster(spec)
+	applySdkErrata(spec)
 
 	return nil
 }

--- a/matter/types/data.go
+++ b/matter/types/data.go
@@ -123,9 +123,9 @@ func ParseDataTypeName(typeName string) (baseType BaseDataType, name string) {
 		baseType = BaseDataTypeMap32
 	case "map64", "bitmap64":
 		baseType = BaseDataTypeMap64
-	case "string", "character string", "char_string":
+	case "string", "character string", "char_string", "long_char_string", "long char string":
 		baseType = BaseDataTypeString
-	case "octstr", "octet string", "octet_string":
+	case "octstr", "octet string", "octet_string", "long_octet_string", "long octet string":
 		baseType = BaseDataTypeOctStr
 	case "percent":
 		baseType = BaseDataTypePercent

--- a/sdk/enum.go
+++ b/sdk/enum.go
@@ -17,9 +17,6 @@ func applyErrataToEnum(en *matter.Enum, typeNames map[string]string, typeOverrid
 			if override.OverrideType != "" {
 				en.Type = types.ParseDataType(override.OverrideType, types.DataTypeRankScalar)
 			}
-			if len(override.Fields) == 0 {
-				return
-			}
 			for _, f := range override.Fields {
 				for _, ev := range en.Values {
 					if ev.Name == f.Name {
@@ -29,9 +26,28 @@ func applyErrataToEnum(en *matter.Enum, typeNames map[string]string, typeOverrid
 						if f.Conformance != "" {
 							ev.Conformance = conformance.ParseConformance(f.Conformance)
 						}
+						if f.Value != "" {
+							ev.Value = matter.ParseNumber(f.Value)
+						}
 						break
 					}
 				}
+			}
+			for _, f := range override.ExtraFields {
+				ev := matter.NewEnumValue(en.Source(), en)
+				ev.Name = f.Name
+				if f.OverrideName != "" {
+					ev.Name = f.OverrideName
+				}
+				if f.Conformance != "" {
+					ev.Conformance = conformance.ParseConformance(f.Conformance)
+				} else {
+					ev.Conformance = conformance.Set{&conformance.Mandatory{}}
+				}
+				if f.Value != "" {
+					ev.Value = matter.ParseNumber(f.Value)
+				}
+				en.Values = append(en.Values, ev)
 			}
 		}
 	}

--- a/sdk/errata.go
+++ b/sdk/errata.go
@@ -80,6 +80,35 @@ func ApplyErrata(spec *spec.Specification, opts ...ApplyErrataOption) (err error
 			addedExtraEntities = true
 		}
 	}
+	for entity, doc := range spec.GlobalObjects {
+		errata := spec.Errata.Get(doc.Path.Relative)
+		if errata == nil || !errata.SDK.HasSdkPatch() {
+			continue
+		}
+		typeOverrides := errata.SDK.Types
+		typeNames := errata.SDK.TypeNames
+		switch entity := entity.(type) {
+		case *matter.Bitmap:
+			applyErrataToBitmap(entity, typeNames, typeOverrides)
+		case *matter.Enum:
+			applyErrataToEnum(entity, typeNames, typeOverrides)
+		case *matter.Struct:
+			err = applyErrataToStruct(entity, typeNames, typeOverrides)
+			if err != nil {
+				return err
+			}
+		case *matter.Command:
+			err = applyErrataToCommand(entity, typeNames, typeOverrides)
+			if err != nil {
+				return err
+			}
+		case *matter.Event:
+			err = applyErrataToEvent(entity, typeNames, typeOverrides)
+			if err != nil {
+				return err
+			}
+		}
+	}
 	if addedExtraEntities {
 		spec.ResolveDataTypeReferences()
 		spec.BuildDataTypeReferences()


### PR DESCRIPTION
# IDL Per-Trait Rendering, Errata Keep Overrides, and Keep-Existing Feature Removal

## Summary
This pull request introduces support for granular, trait-level IDL file generation and errata-driven overrides, while cleaning up high-risk file-parsing features. 

Specifically, it enables splitting the monolithic IDL layout into cluster-specific `.matter` files, implements Go casing logic that exactly replicates Python codegen naming transformations to name these files dynamically, adds errata configuration fields to preserve specific provisional elements or force their visibility scope (local vs global), and removes the brittle, disk-reading `keep-existing` provisional filtering logic.

## Changes

### Errata Schema & Logic overrides
* Added Keep, ForceGlobal, and ForceLocal flags to errata SDK type config schemas.
* Supported retrieving errata overrides inside IDL rendering to move bitmaps, enums, and structs between local and global scopes.
* Implemented bypassed provisional filtering for elements explicitly marked as Keep in the errata configs. Kept provisional elements retain their provisional annotations in the rendered templates.

### Granular Per-Trait IDL Generation
* Introduced a `--per-trait` command-line option to compile and write separate `.matter` files for each cluster.
* Added standard casing logic that replicates Python ToLowerSnakeCase string splits and replace terms.
* Linked this logic with Alchemy's internal caseify helper to dynamically convert spec titles (e.g., "On/Off" or "PM2.5 Concentration Measurement") into their proper snake-case filenames (e.g., "on_off.matter", "pm25_concentration_measurement.matter") without requiring a hardcoded list of mappings.

### Cleanups
* Removed the risk-prone `keep-existing` provisional suppression option.
* Deleted the related disk-reading helper functions (parseExistingMatterElements and isElementPresent) and removed its unit and integration tests.

## Testing
* Added getClusterFileName unit test suite covering a variety of cluster spec titles and acronym scenarios.
* All Go test suites compiled and passed successfully.
