### PR TITLE
Fix zap device type rendering

### DIFF
--- a/zap/render/composed.go
+++ b/zap/render/composed.go
@@ -202,8 +202,8 @@ func getConformanceState(cxt conformance.Context, clusterRequirements []*matter.
 	}
 
 	switch req.Origin {
-	case matter.RequirementOriginBaseDeviceType, matter.RequirementOriginSubsetDeviceType:
-		// Normally, we do not include clusters from the Base Device Type or subset device types...
+	case matter.RequirementOriginSubsetDeviceType:
+		// Normally, we do not include clusters from subset device types...
 
 		var hasElements bool
 		ers := elementRequirements[req.ClusterRequirement.Cluster]

--- a/zap/render/conformance.go
+++ b/zap/render/conformance.go
@@ -11,9 +11,6 @@ import (
 
 func renderConformance(spec *spec.Specification, entity types.Entity, c conformance.Conformance, parent *etree.Element, alternatives ...string) error {
 	removeConformance(parent)
-	if conformance.IsMandatory(c) && !conformance.IsProvisional(c) {
-		return nil
-	}
 	conformanceElement, err := dm.CreateConformanceElement(c, nil)
 	if err != nil {
 		return err


### PR DESCRIPTION
### Summary

- Include Base Device Type requirements (e.g. Descriptor cluster) across all device types in ZAP XML.
- Render explicit `<mandatoryConform />` tags for mandatory features in ZAP XML.

### Changes

- `zap/render/composed.go`: Stop suppressing Base Device Type cluster requirements so all device types inherit base clusters like Descriptor.
- `zap/render/conformance.go`: Render explicit `<mandatoryConform />` tags for unconditional mandatory elements.

### Testing

- Ran `go test ./...` in Alchemy (all tests pass).
- Regenerated `matter-devices.xml` and verified that Descriptor cluster and mandatory feature conformances are present across all device types.